### PR TITLE
Fix charset to fit IANA standard

### DIFF
--- a/protocol.md
+++ b/protocol.md
@@ -29,7 +29,7 @@ Currently the following header fields are supported:
 | Header File Name | Value Type  | Description |
 |:-----------------|:------------|:------------|
 | Content-Length   | number      | The length of the content part in bytes. This header is required. |
-| Content-Type     | string      | The mime type of the content part. Defaults to application/vscode-jsonrpc; charset=utf8 |
+| Content-Type     | string      | The mime type of the content part. Defaults to application/vscode-jsonrpc; charset=utf-8 |
 
 The header part is encoded using the 'ascii' encoding. This includes the '\r\n' separating the header and content part.
 


### PR DESCRIPTION
Per the character sets listed in the standard: http://www.iana.org/assignments/character-sets/character-sets.xhtml, 'utf8' is not the name of the character encoding. The correct encoding name is 'utf-8'. Correcting this brings it in conformance with web standards, allowing more interoperability. In particular .NET's Encoding.GetEncoding(string) function only returns an Encoding instance for 'utf-8' and null for 'utf8'.

See also: http://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.7

Note that correcting the doc is just one step. The code that produces and consumes this header in VS Code should also be checked and fixed if necessary.
