### PR TITLE
DidOpenTextDocumentParams does not extend TextDocumentIdentifier

### DIFF
--- a/protocol.md
+++ b/protocol.md
@@ -765,7 +765,7 @@ _Notification_:
 * method: 'textDocument/didOpen'
 * params: `DidOpenTextDocumentParams` defined as follows:
 ```typescript
-interface DidOpenTextDocumentParams extends TextDocumentIdentifier {
+interface DidOpenTextDocumentParams {
 	/**
 	 * The document that was opened.
 	 */


### PR DESCRIPTION
See https://github.com/Microsoft/vscode-languageserver-node/blob/032c12a09cf19ad7fb6af997beca1d5f6a7f34b2/server/src/protocol.ts#L411-L416.

The `uri` field is present in the `TextDocumentItem` in any case.