### PR TITLE
Protocol addition to get SymbolInformation for a given text document position

### DIFF
--- a/protocol.md
+++ b/protocol.md
@@ -581,6 +581,10 @@ interface ServerCapabilities {
 	 */
 	definitionProvider?: boolean;
 	/**
+	 * The server provides get symbol support.
+	 */
+	symbolProvider?: boolean;
+	/**
 	 * The server provides find references support.
 	 */
 	referencesProvider?: boolean;
@@ -1207,6 +1211,18 @@ _Request_
 
 _Response_:
 * result: [`Location`](#location) | [`Location`](#location)[]
+* error: code and message set in case an exception happens during the definition request.
+
+#### Get Symbol Request
+
+The get symbol request is sent from the client to the server to resolve the definition location and symbol information for a given text document position.
+
+_Request_
+* method: 'textDocument/symbol'
+* params: [`TextDocumentPositionParams`](#textdocumentpositionparams)
+
+_Response_:
+* result: `SymbolInformation` | `SymbolInformation`[]
 * error: code and message set in case an exception happens during the definition request.
 
 #### Find References Request


### PR DESCRIPTION
I'm developing a plugin to allow developers to look up global usages of a given symbol. I’ve also see plugins that automatically link you to the godoc for a symbol (in the case of Go), and plugins that automatically search StackOverflow or Google, to which this protocol change would also apply.

To build these plugins, one needs to know the information about the symbol under the cursor - for instance, in a go example, if the user wants to find the godoc page for `mux.Router`, we need to construct the url `https://godoc.org/github.com/gorilla/mux#Router`, which requires knowing  the name (Router), the parent, the package (mux), and the git url (github.com/gorilla/mux). The `SymbolInformation` data type returned by `workspace/symbol` and `textDocument/documentSymbol` is exactly what we need.

Currently, to create such a plugin and get the `SymbolInformation` required, I find myself needing to request `textDocument/definition` for the `TextDocumentPostionParams` in question. Then, I need to request `textDocument/documentSymbol,` and iterate through the returned symbols to find the one with the same `Location` as the `textDocument/definition.`

The problem with this approach is that it requires two requests, the second of which can be expensive. I wanted to propose a modification to the protocol that would solve the above problem, which seems like it will come up for many types of plugins one could imagine writing. Here are some options I considered:
1. `textDocument/definition` should return `SymbolInformation` (a superset of `Location`). Upside: Only one request to perform. Downside: Perhaps there are some implementations of `textDocument/definition` that are cheaper and faster without needing the full `SymbolInformation,` so we shouldn’t penalize this API call.
2. (The option presented in this PR) Given the downside from 1, creating a new protocol message `textDocument/symbol`, which returns `SymbolInformation`. Upside: Same as above. Downside: One more request to implement for language server creators.
3. Adding an optional `Location` parameter to the `textDocument/documentSymbol` request, that would focus the search in a text document to just the range attached to the location. Upside: Potentially can speed up `textDocument/documentSymbol` request by not analyzing and returning `SymbolInformation` for out of scope symbols. Downside: The above process still requires two requests, and performance difference will probably vary based on language server implementation.

Open to any other suggestions and feedback on how to solve the above problem, and curious to hear if anyone else is running into this.
