### PR TITLE
Clarify what is meant by definition location for textDocument/definition

### DIFF
--- a/protocol.md
+++ b/protocol.md
@@ -1199,7 +1199,7 @@ interface ParameterInformation {
 
 #### Goto Definition Request
 
-The goto definition request is sent from the client to the server to resolve the definition location of a symbol at a given text document position.
+The goto definition request is sent from the client to the server to resolve the definition location of a symbol at a given text document position. The location is the entire range of the definition, e.g. the entire range of a function starting from its signature to the final closing code bracket.
 
 >**Changed:** In 2.0 the request uses `TextDocumentPositionParams` with proper `textDocument` and `position` properties. In 1.0 the uri of the referenced text document was inlined into the params object. 
 


### PR DESCRIPTION
Currently, the protocol states that:
```
The goto definition request is sent from the client to the server to resolve the definition location of a symbol at a given text document position.
```

It isn't clear, in the case of a struct Foo, whether this definition location should encompass _just_ the token `Foo`, or the entire body of the definition of the Foo struct:
```
type Foo struct {
    Bar bar
}
```

It seems like it should resolve to the entire body because:
- Visual Studio Code [hover preview depends on it](https://sourcegraph.com/github.com/Microsoft/vscode/-/blob/src/vs/editor/contrib/goToDeclaration/browser/goToDeclaration.ts#L329-334) spanning the body.
- It is more useful for many kinds of analysis e.g. determining function dependencies.