### PR TITLE
Added ComplexDiagnostic

### DIFF
--- a/protocol.md
+++ b/protocol.md
@@ -375,6 +375,24 @@ namespace DiagnosticSeverity {
 }
 ```
 
+#### ComplexDiagnostic
+
+Represents a complex diagnostic, such as a compiler complex error or warning. ComplexDiagnostic objects are only valid in the scope of a resource.
+
+```typescript
+interface ComplexDiagnostic {
+	/**
+	 * A valuable diagnostic
+	 */
+	mainDiagnostic: Diagnostic;
+
+	/**
+	 * An array of helpful, but less valuable diagnostics
+	 */
+	slaveDiagnostics: Diagnostic[];
+}
+```
+
 #### Command
 
 Represents a reference to a command. Provides a title which will be used to represent a command in the UI. Commands are identitifed using a string identifier and the protocol currently doesn't specify a set of well known commands. So executing a command requires some tool extension code.
@@ -1678,6 +1696,11 @@ interface PublishDiagnosticsParams {
 	 * An array of diagnostic information items.
 	 */
 	diagnostics: Diagnostic[];
+
+	/**
+	 * An array of complex diagnostic information items.
+	 */
+	complexDiagnostics: Diagnostic[];
 }
 ```
 


### PR DESCRIPTION
Hi everybody.

Currently there is no way to show complex diagnostics.

Rust have very useful and detailed messages.

For code:

```rust
fn main() {
    let mut x = &5;
    {
        let y = 5;
        x = &y;
    }
}
```

It gives very good explanation:
```
error: `y` does not live long enough
 --> main.rs:6:5
  |
5 |         x = &y;
  |              - borrow occurs here
6 |     }
  |     ^ `y` dropped here while still borrowed
7 | }
  | - borrowed value needs to live until here
```

I am using VSCode.
Rust Language Server (RLS) is currently being developed.
RLS can send all of aforementioned messages, but there will be problems when multiple messages have same range.

![rls](https://cloud.githubusercontent.com/assets/11215191/22245388/09e8e8c0-e249-11e6-9a90-80cab6930c5f.png)

There are errors on both 7 and 8 lines.
They point to both 9 and 10 lines.

This is how it works with code lenses:

![screenshot 1](https://cloud.githubusercontent.com/assets/11215191/22255752/72712c48-e269-11e6-9f86-873991b3ed37.png)

I'd like to have a way to show only primary message and if a user hover on the message to show all secondary messages.
Currently there is no way to show such kind of messages in VSCode.