### PR TITLE
Correct log message heading in protocol v1

### DIFF
--- a/versions/protocol-1-x.md
+++ b/versions/protocol-1-x.md
@@ -591,7 +591,7 @@ enum MessageType {
 }
 ```
 
-#### ShowMessage Notification
+#### LogMessage Notification
 
 The log message notification is send from the server to the client to ask the client to log a particular message.
 


### PR DESCRIPTION
Was a duplicate of the show message heading.