### PR TITLE
DidChange might only have new text

### DIFF
--- a/protocol.md
+++ b/protocol.md
@@ -1526,7 +1526,7 @@ interface TextDocumentContentChangeEvent {
 	rangeLength?: number;
 
 	/**
-	 * The new text of the document.
+	 * The new text of the range/document.
 	 */
 	text: string;
 }


### PR DESCRIPTION
Currently the spec says that `TextDocumentContentChangeEvent.text` contains the new text of the *document*.

I assume that, if the server requested incremental changes and if the client obliged by sending a range+rangelength, then the `text` field merely contains the new text of the *range*.