### PR TITLE
Fix typo in summary of `interface Registration`.

### DIFF
--- a/protocol.md
+++ b/protocol.md
@@ -1343,7 +1343,7 @@ Where `RegistrationParams` are defined as follows:
 
 ```typescript
 /**
- * General paramters to regsiter for a capability.
+ * General paramters to register for a capability.
  */
 export interface Registration {
 	/**

--- a/protocol.md
+++ b/protocol.md
@@ -1409,7 +1409,7 @@ _Response_:
 
 > #### New: <a name="client_unregisterCapability"></a>Unregister Capability
 
-The `client/unregisterCapability` request is sent from the server to the client to unregister a previously register capability.
+The `client/unregisterCapability` request is sent from the server to the client to unregister a previously registered capability.
 
 _Request_:
 * method: 'client/unregisterCapability'

--- a/protocol.md
+++ b/protocol.md
@@ -1343,7 +1343,7 @@ Where `RegistrationParams` are defined as follows:
 
 ```typescript
 /**
- * General paramters to to regsiter for a capability.
+ * General paramters to regsiter for a capability.
  */
 export interface Registration {
 	/**


### PR DESCRIPTION
There seems to be an extra "to" in the annotation for the interface `Registration`.