### PR TITLE
Order of multiple TextDocumentContentChangeEvent

### DIFF
--- a/protocol.md
+++ b/protocol.md
@@ -1496,6 +1496,8 @@ _Registration Options_: `TextDocumentRegistrationOptions`
 
 The document change notification is sent from the client to the server to signal changes to a text document. In 2.0 the shape of the params has changed to include proper version numbers and language ids.
 
+Similarly to `TextEdit`, if multiple `contentChange`s are applied to a text document, all text edits describe changes made to the initial document version. Execution-wise text edits should be applied from the bottom to the top of the text document. Overlapping text edits are not supported.
+
 _Notification_:
 * method: 'textDocument/didChange'
 * params: `DidChangeTextDocumentParams` defined as follows:


### PR DESCRIPTION
What should happen if `textDocument/didChange` contains multiple `contentChanges`? This will happen if (1) an editor client supports multiple cursors, and (2) a language server supports incremental edits.

(Contrast with `TextEdit`, where in cases where the LSP server sends multiple `TextEdit`s to the client, the client is expected to sort them in reverse order).

I think that for uniformity with `TextEdit`, we should say that whoever receives an array of edits (be they `TextEdit`s or `TextDocumentContentChangeEvent`s) is responsible for sorting them and applying them in reverse order. And whoever sends them is responsible for ensuring that they're non-overlapping.

Of course, most LSP servers don't yet do this. Most of them at the moment seem to just apply the array of edits blindly in the order in which they were received.

I think therefore, in our transitional period up until LSP servers start doing that, the clients should (for convenience and compatibility) do the sorting themselves. Atom editor already does, and VSCode editor should follow suite.
https://github.com/atom/atom-languageclient/issues/72
