### PR TITLE
Multiple text document changes when setting the entire content

### DIFF
--- a/protocol.md
+++ b/protocol.md
@@ -1517,7 +1517,8 @@ interface DidChangeTextDocumentParams {
 
 /**
  * An event describing a change to a text document. If range and rangeLength are omitted
- * the new text is considered to be the full content of the document.
+ * the new text is considered to be the full content of the document, and this change
+ * must be the only element of `contentChanges`.
  */
 interface TextDocumentContentChangeEvent {
 	/**


### PR DESCRIPTION
It's unclear how a language server should react when multiple changes to the text document are sent, and one or more set the content of the entire document.

The convention so far among the language servers I've seen has been to apply the changes from the bottom of the document to the top. However, there is no obvious ordering for the whole-document changes. Should we apply the changes in the order that they are received (so that earlier whole-document changes are overridden by later whole-document changes), except that within consecutive subsequences of range-changes we apply them in bottom-to-top order?

This is a non-trivial amount of complexity for a situation that probably never arises in practice. Most likely the editor will either set the entire text of the document, or set ranges for the changes to the document (where, in some cases, the range may be the whole document). This commit clarifies this by forbidding whole-document changes in conjunction with other changes. It's also in line with the idea of forbidding overlapping edits as per #279.