### PR TITLE
Fixing 'paramters' and 'reponse' typos

### DIFF
--- a/protocol.md
+++ b/protocol.md
@@ -595,7 +595,7 @@ This section documents the actual language server protocol. It uses the followin
 
 #### Request, Notification and response ordering
 
-Responses for requests should be sent in the same order as the requests appear on the server or client side. So for example if a server receives a `textDocument/completion` request and then a `textDocument/signatureHelp` request it should first return the response for the `textDocument/completion` and then the reponse for `textDocument/signatureHelp`.
+Responses for requests should be sent in the same order as the requests appear on the server or client side. So for example if a server receives a `textDocument/completion` request and then a `textDocument/signatureHelp` request it should first return the response for the `textDocument/completion` and then the response for `textDocument/signatureHelp`.
 
 How the server internally processes the requests is up to the server implementation. If the server decides to execute them in parallel and this produces correct result the server is free to do so. The server is also allowed to reorder requests and notification if the reordering doesn't affect correctness.
 

--- a/protocol.md
+++ b/protocol.md
@@ -1344,7 +1344,7 @@ Where `RegistrationParams` are defined as follows:
 
 ```typescript
 /**
- * General paramters to register for a capability.
+ * General parameters to register for a capability.
  */
 export interface Registration {
 	/**


### PR DESCRIPTION
Like it says on the tin.