### PR TITLE
Clarify response ordering (#306)

### DIFF
--- a/protocol.md
+++ b/protocol.md
@@ -599,9 +599,9 @@ This section documents the actual language server protocol. It uses the followin
 
 #### Request, Notification and response ordering
 
-Responses for requests should be sent in the same order as the requests appear on the server or client side. So for example if a server receives a `textDocument/completion` request and then a `textDocument/signatureHelp` request it should first return the response for the `textDocument/completion` and then the response for `textDocument/signatureHelp`.
+Responses to requests should be sent in the roughly same order as the requests appear on the server or client side. So for example if a server receives a `textDocument/completion` request and then a `textDocument/signatureHelp` request it will usually first return the response for the `textDocument/completion` and then the response for `textDocument/signatureHelp`.
 
-How the server internally processes the requests is up to the server implementation. If the server decides to execute them in parallel and this produces correct result the server is free to do so. The server is also allowed to reorder requests and notification if the reordering doesn't affect correctness.
+However, the server may decide to use a parallel execution strategy and may wish to return responses in a different order than the requests were received. The server may do so as long as this reordering doesn't affect the correctness of the responses. For example, reordering the result of `textDocument/completion` and `textDocument/signatureHelp` is allowed, as these each of these requests usually won't affect the output of the other. On the other hand, the server most likely should not reorder `textDocument/definition` and `textDocument/rename` requests, since the executing the latter may affect the result of the former.
 
 #### Server lifetime
 


### PR DESCRIPTION
This clarifies what the server is allowed to do in regard to reordering responses to requests, as per the discussion in #306 and https://github.com/freebroccolo/ocaml-language-server/issues/59.