### PR TITLE
Add ClientCapabilities.dynamicRegistration

### DIFF
--- a/protocol.md
+++ b/protocol.md
@@ -960,6 +960,11 @@ interface ClientCapabilities {
 	textDocument?: TextDocumentClientCapabilities;
 
 	/**
+	 * Client supports the `client/registerCapability` request from server.
+	 */
+	dynamicRegistration?: Boolean;
+
+	/**
 	 * Experimental client capabilities.
 	 */
 	experimental?: any;


### PR DESCRIPTION
The documentation about client/registerCapability references a ClientCapabilities.dynamicRegistration field that's missing from the current ClientCapabilities description (so it's easily forgotten in related libraries such as LSP4J).