### PR TITLE
Correct atom-languageclient link

### DIFF
--- a/_implementors/tools.md
+++ b/_implementors/tools.md
@@ -17,7 +17,7 @@ index: 2
 | emacs | [Vibhav Pant](https://github.com/vibhavp) | [emacs language server client](https://github.com/emacs-lsp/lsp-mode/) |
 |[GNOME Builder](https://wiki.gnome.org/Apps/Builder)| [gnome.org](https://wiki.gnome.org/Apps/Builder/) | [language server client](https://git.gnome.org/browse/gnome-builder/tree/src/libide/langserv) |
 |[MS Monaco Editor](https://github.com/Microsoft/monaco-editor)| [Typefox](https://github.com/TypeFox) | [monaco-languageclient](https://www.npmjs.com/package/monaco-languageclient) |
-|[Atom](https://atom.io/)| [Github](https://github.com/) | [atom-languageclient](https://atom.io/packages/atom-languageclient) |
+|[Atom](https://atom.io/)| [GitHub](https://github.com/) | [atom-languageclient](https://www.npmjs.com/package/atom-languageclient) |
 |[Theia](https://github.com/theia-ide/theia)| [theia-ide](https://github.com/theia-ide) | [theia](https://github.com/theia-ide/theia) |
 |vim8 and [neovim](https://neovim.io/)| [Junfeng Li](https://github.com/autozimu) | [LanguageClient-neovim](https://github.com/autozimu/LanguageClient-neovim) |
 |vim8 and neovim| [Prabir Shrestha](https://github.com/prabirshrestha) | [vim-lsp](https://github.com/prabirshrestha/vim-lsp) |


### PR DESCRIPTION
Link to atom-languageclient was incorrect.  (It is an npm package not an apm one - somebody had published something similar on apm which is now deleted)
  
Fixes #369