### PR TITLE
Change message params types to match JSON-RPC spec

### DIFF
--- a/specification.md
+++ b/specification.md
@@ -195,6 +195,8 @@ A request that got canceled still needs to return from the server and send a res
 
 The language server protocol defines a set of JSON-RPC request, response and notification messages which are exchanged using the above base protocol. This section starts describing the basic JSON structures used in the protocol. The document uses TypeScript interfaces to describe these. Based on the basic JSON structures, the actual requests with their responses and the notifications are described.
 
+In general, the language server protocol supports JSON-RPC messages, however the base protocol defined here uses a convention such that the parameters passed to request/notification messages should be of `object` type (if passed at all). However, this does not disallow using `Array` parameter types in custom messages.
+
 The protocol currently assumes that one server serves one tool. There is currently no support in the protocol to share one server between different tools. Such a sharing would require additional protocol to either lock a document to support concurrent editing.
 
 ### Basic JSON Structures

--- a/specification.md
+++ b/specification.md
@@ -89,7 +89,7 @@ interface RequestMessage extends Message {
 	/**
 	 * The method's params.
 	 */
-	params?: any
+	params?: Array<T> | object;
 }
 ```
 
@@ -164,7 +164,7 @@ interface NotificationMessage extends Message {
 	/**
 	 * The notification's params.
 	 */
-	params?: any
+	params?: Array<T> | object;
 }
 ```
 

--- a/specification.md
+++ b/specification.md
@@ -89,7 +89,7 @@ interface RequestMessage extends Message {
 	/**
 	 * The method's params.
 	 */
-	params?: Array<T> | object;
+	params?: Array<any> | object;
 }
 ```
 
@@ -164,7 +164,7 @@ interface NotificationMessage extends Message {
 	/**
 	 * The notification's params.
 	 */
-	params?: Array<T> | object;
+	params?: Array<any> | object;
 }
 ```
 


### PR DESCRIPTION
Since the interface is supposed to describe message format to match [JSON-RPC spec](http://www.jsonrpc.org/specification),
the params type must be specified as either `Array` or `Object`.

From spec:
> 4.2 Parameter Structures
>
> If present, parameters for the rpc call MUST be provided as a Structured value. Either by-position through an Array or by-name through an Object.