### PR TITLE
Fix code block formatting

### DIFF
--- a/specification.md
+++ b/specification.md
@@ -1842,6 +1842,7 @@ export interface ApplyWorkspaceEditParams {
 
 _Response_:
 * result: `ApplyWorkspaceEditResponse` defined as follows:
+
 ```typescript
 export interface ApplyWorkspaceEditResponse {
 	/**
@@ -2819,7 +2820,8 @@ The document links request is sent from the client to the server to request the 
 
 _Request_:
 * method: 'textDocument/documentLink'
-* params: `DocumentLinkParams`, defined as follows
+* params: `DocumentLinkParams`, defined as follows:
+
 ```typescript
 interface DocumentLinkParams {
 	/**


### PR DESCRIPTION
- Fix code block formatting for DocumentLinkParams and ApplyWorkspaceEditResponse

formatting errors can be seen [here](https://microsoft.github.io/language-server-protocol/specification#workspace_applyEdit) and [here](https://microsoft.github.io/language-server-protocol/specification#textDocument_documentLink)