### PR TITLE
Add a new CompletionTriggerKind.TriggerForIncompleteCompletions for re-triggers

### DIFF
--- a/specification.md
+++ b/specification.md
@@ -2118,8 +2118,13 @@ export namespace CompletionTriggerKind {
 	 * the `triggerCharacters` properties of the `CompletionRegistrationOptions`.
 	 */
 	export const TriggerCharacter: 2 = 2;
+
+	/**
+	 * Completion was re-triggered as the current completion list is incomplete.
+	 */
+	export const TriggerForIncompleteCompletions: 3 = 3;
 }
-export type CompletionTriggerKind = 1 | 2;
+export type CompletionTriggerKind = 1 | 2 | 3;
 
 
 /**


### PR DESCRIPTION
A new `CompletionTriggerKind` named `TriggerForIncompleteCompletions` has been added to the vscode-languageserver-node repository in Microsoft/vscode-languageserver-node#308. I have updated the specification so that they can be in sync with each other.