### PR TITLE
Make the description of textDocument/didOpen less ambiguous

### DIFF
--- a/specification.md
+++ b/specification.md
@@ -1856,7 +1856,7 @@ export interface ApplyWorkspaceEditResponse {
 
 #### <a name="textDocument_didOpen" class="anchor"></a>DidOpenTextDocument Notification (:arrow_right:)
 
-The document open notification is sent from the client to the server to signal newly opened text documents. The document's truth is now managed by the client and the server must not try to read the document's truth using the document's uri. Open in this sense means it is managed by the client. It doesn't necessarily mean that its content is presented in an editor. An open notification must not be sent more than once without a corresponding close notification send before. This means open and close notification must be balanced and the max open count is one. 
+The document open notification is sent from the client to the server to signal newly opened text documents. The document's truth is now managed by the client and the server must not try to read the document's truth using the document's uri. Open in this sense means it is managed by the client. It doesn't necessarily mean that its content is presented in an editor. An open notification must not be sent more than once without a corresponding close notification send before. This means open and close notification must be balanced and the max open count for a particular textDocument is one. 
 
 _Notification_:
 * method: 'textDocument/didOpen'


### PR DESCRIPTION
Changed the sentence
> This means open and close notification must be balanced and the max open count is one. 

into

> This means open and close notification must be balanced and the max open count for a particular textDocument is one. 

Related issue: https://github.com/Microsoft/language-server-protocol/issues/407