### PR TITLE
Escape pipe characters so that they get rendered in HTML

### DIFF
--- a/specification.md
+++ b/specification.md
@@ -2759,7 +2759,7 @@ _Request_:
 * params: [`TextDocumentPositionParams`](#textdocumentpositionparams)
 
 _Response_:
-* result: [`Location`](#location) | [`Location`](#location)[] \| `null`
+* result: [`Location`](#location) \| [`Location`](#location)[] \| `null`
 * error: code and message set in case an exception happens during the definition request.
 
 _Registration Options_: `TextDocumentRegistrationOptions`
@@ -2775,7 +2775,7 @@ _Request_:
 * params: [`TextDocumentPositionParams`](#textdocumentpositionparams)
 
 _Response_:
-* result: [`Location`](#location) | [`Location`](#location)[] | `null`
+* result: [`Location`](#location) \| [`Location`](#location)[] \| `null`
 * error: code and message set in case an exception happens during the definition request.
 
 _Registration Options_: `TextDocumentRegistrationOptions`
@@ -2791,7 +2791,7 @@ _Request_:
 * params: [`TextDocumentPositionParams`](#textdocumentpositionparams)
 
 _Response_:
-* result: [`Location`](#location) | [`Location`](#location)[] | `null`
+* result: [`Location`](#location) \| [`Location`](#location)[] \| `null`
 * error: code and message set in case an exception happens during the definition request.
 
 _Registration Options_: `TextDocumentRegistrationOptions`


### PR DESCRIPTION
The pipe characters aren't being rendered in HTML. We need to escape them so they'll show up.

![image](https://user-images.githubusercontent.com/15629116/37961966-aed9835c-31f4-11e8-82a8-6928dfa495b0.png)