### PR TITLE
Send configuration on language server startup

### DIFF
--- a/specification.md
+++ b/specification.md
@@ -723,6 +723,12 @@ interface InitializeParams {
 	 */
 	initializationOptions?: any;
 
+	/*
+	 * Configuration settings in the client. These can be changed later by the
+	 * client by issuing a `workspace/didChangeConfiguration` notification.
+	 */
+	settings?: any;
+
 	/**
 	 * The capabilities provided by the client (editor or tool)
 	 */


### PR DESCRIPTION
There's currently a method of sending configuration to the language server using the `workspace/didChangeConfiguration` notification. However, the configuration is not available on language server initialization. This could be benign, or it could mean that the language server has to stop doing work with a default configuration and start doing work with the updated configuration, such as in #54.

In the Hack language server, we would like to support a "dynamic view", which shows additional type errors for the file that you're looking at using a different, more strict interpretation of the `any` type (cc @jamesjwu). This can be toggled on and off in the editor as the user needs it. It's not feasible to restart the language server whenever we want to change this setting because the language server takes anywhere from 30 seconds to 10 minutes to start up.

The difference between `initializationOptions` and `settings`, then, is that the former doesn't change once the language server is initialized, and the latter can change when the user changes their configuration in the editor.