### PR TITLE
Change workspace/configuration's icon to be a request

### DIFF
--- a/specification.md
+++ b/specification.md
@@ -1845,7 +1845,7 @@ interface DidChangeConfigurationParams {
 }
 ```
 
-#### <a name="workspace_configuration" class="anchor"></a>Configuration Request (:arrow_left:)
+#### <a name="workspace_configuration" class="anchor"></a>Configuration Request (:arrow_right_hook:)
 
 > *Since version 3.6.0*
 


### PR DESCRIPTION
`workspace/configuration` is a request so it should use a hook instead of an arrow to visually indicate to the reader that something will be sent back to the originator of the message.