### PR TITLE
Change workspace/workspaceFolder's icon to be a request

### DIFF
--- a/specification.md
+++ b/specification.md
@@ -1754,7 +1754,7 @@ _Response_:
 * result: void.
 * error: code and message set in case an exception happens during the request.
 
-##### <a name="workspace_workspaceFolders" class="anchor"></a>Workspace folders request (:arrow_left:)
+##### <a name="workspace_workspaceFolders" class="anchor"></a>Workspace folders request (:arrow_right_hook:)
 
 > *Since version 3.6.0*
 


### PR DESCRIPTION
`workspace/workspaceFolder` is a request so it should use a hook instead of an arrow to indicate that a response will be sent back to the originator of the message.