### PR TITLE
Fix #447 Clarify the default for TextDocumentSyncOptions's change

### DIFF
--- a/specification.md
+++ b/specification.md
@@ -1362,7 +1362,7 @@ export interface TextDocumentSyncOptions {
 	openClose?: boolean;
 	/**
 	 * Change notifications are sent to the server. See TextDocumentSyncKind.None, TextDocumentSyncKind.Full
-	 * and TextDocumentSyncKind.Incremental.
+	 * and TextDocumentSyncKind.Incremental. If omitted it defaults to TextDocumentSyncKind.None.
 	 */
 	change?: number;
 	/**


### PR DESCRIPTION
a1b13c56810a2617fcfff9c280d4098602a4fb2f didn't include a change to `TextDocumentSyncOptions`. This pull request adds the text to `TextDocumentSyncOptions`'s `change` field also.