### PR TITLE
Add new data field to DocumentLink to support documentLink/resolve properly

### DIFF
--- a/specification.md
+++ b/specification.md
@@ -3244,6 +3244,11 @@ interface DocumentLink {
 	 * The uri this link points to. If missing a resolve request is sent later.
 	 */
 	target?: DocumentUri;
+	/**
+	 * A data entry field that is preserved on a document link between a
+	 * DocumentLinkRequest and a DocumentLinkResolveRequest.
+	 */
+	data?: any;
 }
 ```
 * error: code and message set in case an exception happens during the document link request.


### PR DESCRIPTION
It's not possible to implement `documentLink/resolve` properly because a `DocumentLink` has no information outside of a non-null `Range` property. Adding a new `data` field to the `DocumentLink` interface will allow information to be transferred and preserved across a `textDocument/documentLink` request and a `documentLink/resolve` request. The server can populate it with whatever it needs on a `textDocument/documentLink` request and then later read it when it later receives a `documentLink/resolve` request.

This fixes #401. See Microsoft/vscode-languageserver-node#336 for the VS Code implementation.