### PR TITLE
Add deprecated property to CompletionItem and SymbolInformation

### DIFF
--- a/specification.md
+++ b/specification.md
@@ -935,6 +935,11 @@ export interface TextDocumentClientCapabilities {
 			 * property. The order describes the preferred format of the client.
 			 */
 			documentationFormat?: MarkupKind[];
+
+			/**
+			 * Client supports the deprecated property on a completion item.
+			 */
+			deprecatedSupport?: boolean;
 		}
 
 		completionItemKind?: {
@@ -2491,6 +2496,11 @@ interface CompletionItem {
 	documentation?: string | MarkupContent;
 
 	/**
+	 * Indicates if this item is deprecated.
+	 */
+	deprecated?: boolean;
+
+	/**
 	 * A string that should be used when comparing this item
 	 * with other items. When `falsy` the label is used.
 	 */
@@ -3032,6 +3042,11 @@ interface SymbolInformation {
 	 * The kind of this symbol.
 	 */
 	kind: number;
+
+	/**
+	 * Indicates if this symbol is deprecated.
+	 */
+	deprecated?: boolean;
 
 	/**
 	 * The location of this symbol. The location's range is used by a tool


### PR DESCRIPTION
It should be possible for completion items and symbols to be flagged as being deprecated. Some editors and IDEs flag such deprecated items by applying a visual affordance such as striking the text out. By introducing this new deprecated property, these editors and IDEs will be able to use its deprecation UI affordance when supporting a language via the LSP.

This implements and closes Microsoft/language-server-protocol#139.

See Microsoft/vscode-languageserver-node#332 for the VS Code implementation.