### PR TITLE
change ruby implementor to solargraph

### DIFF
--- a/_implementors/servers.md
+++ b/_implementors/servers.md
@@ -58,7 +58,7 @@ index: 1
 | Python| [Palantir Technologies](https://github.com/palantir) | [python-language-server](https://github.com/palantir/python-language-server) |
 | R | [REditorSupport](https://github.com/REditorSupport) | [R language server](https://github.com/REditorSupport/languageserver) |
 | RAML | [RAML Workgroup](http://raml.org/about/workgroup) | [raml-language-server](https://github.com/raml-org/raml-language-server) Work in Progress |
-| Ruby| [Fumiaki MATSUSHIMA](https://github.com/mtsmfm) | [language_server-ruby](https://github.com/mtsmfm/language_server-ruby) |
+| Ruby| [Fred Snyder](https://github.com/castwide) | [solargraph](https://github.com/castwide/solargraph) |
 | Rust | [Jonathan Turner](https://github.com/jonathandturner) | [rustls](https://github.com/jonathandturner/rustls) |
 | SQL | MS | [VS Code SQL extension](https://github.com/Microsoft/vscode-mssql/tree/dev/src/languageservice ) |
 | Scala | [Iulian Dragos](https://github.com/dragos) | [dragos-vscode-scala](https://github.com/dragos/dragos-vscode-scala) |


### PR DESCRIPTION
There was not much activity on language_server-ruby recently. 
It was using rcodetools (a very outdated gem, which could not work properly)
The gem was removed. The only ruby native solution for static analysis available is solargraph
And it has implemented a language server on its own, which is quite feature complete.
The language server was also used by sourcegraph.
https://github.com/castwide/solargraph/issues/8