### PR TITLE
Fix minor syntax mistakes

### DIFF
--- a/specification.md
+++ b/specification.md
@@ -1987,7 +1987,7 @@ _Registration Options_: `DidChangeWatchedFilesRegistrationOptions` defined as fo
 
 ```typescript
 /**
- * Describe options to be used when registered for text document change events.
+ * Describe options to be used when registering for text document change events.
  */
 export interface DidChangeWatchedFilesRegistrationOptions {
 	/**
@@ -2209,7 +2209,7 @@ _Registration Options_: `TextDocumentChangeRegistrationOptions` defined as follo
 
 ```typescript
 /**
- * Describe options to be used when registered for text document change events.
+ * Describe options to be used when registering for text document change events.
  */
 export interface TextDocumentChangeRegistrationOptions extends TextDocumentRegistrationOptions {
 	/**


### PR DESCRIPTION
Unless it's me who doesn't understand the sentence, I think "registering" was meant to be used in these two places, instead of "registered".