### PR TITLE
Update Puppet Language Server Info

### DIFF
--- a/_implementors/servers.md
+++ b/_implementors/servers.md
@@ -57,7 +57,7 @@ index: 1
 | [Polymer](https://www.polymer-project.org) | [Polymer Team](https://github.com/Polymer) | [polymer-editor-service](https://github.com/Polymer/polymer-editor-service) |
 | PowerShell | MS |  [VS Code PowerShell extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.PowerShell) |
 | PureScript | [Nicholas Wolverson](https://github.com/nwolverson) | [purescript-language-server](https://github.com/nwolverson/purescript-language-server) |
-| Puppet| [Puppetlabs](https://github.com/jpogran) | [puppet language server](https://github.com/jpogran/puppet-vscode/tree/master/server) |
+| Puppet| [Lingua Pupuli](https://github.com/lingua-pupuli) | [puppet language server](https://github.com/lingua-pupuli/puppet-editor-services) |
 | Python| [Fabio Zadrozny](https://github.com/fabioz/) | [PyDev on VSCode](http://www.pydev.org/vscode/index.html) |
 | Python| [Palantir Technologies](https://github.com/palantir) | [python-language-server](https://github.com/palantir/python-language-server) |
 | Python | MS | [Python Tools for Visual Studio](https://github.com/Microsoft/PTVS)


### PR DESCRIPTION
Prior to this commit the information for the Puppet language server pointed to @jpogran's personal repository, which was accurate.

However, the project has been split out and matured in the Lingua Pupuli namespace. The server, client, and related projects are now grouped there together. The maintainers are Puppet employees.