### PR TITLE
Add preselect field to CompletionItem

### DIFF
--- a/specification.md
+++ b/specification.md
@@ -2535,6 +2535,13 @@ interface CompletionItem {
 	filterText?: string;
 
 	/**
+	 * Select this item when showing. *Note* that only one completion item can be selected and
+	 * that the editor decides which item that is. The rule is that the *first* item of those
+	 * that match best is selected.
+	 */
+	preselect?: boolean;
+
+	/**
 	 * A string that should be inserted into a document when selecting
 	 * this completion. When `falsy` the label is used.
 	 *


### PR DESCRIPTION
Fixes #515 

VS Code 1.25 adds new `preselect` field to the `CompletionItem`. The field allows completion providers to specify which item should be initially selected in the completion list. 

By default clients usually select first or last used items, which is limiting. A completion provider may choose to select different item based on other conditions, such as current code editor context, probability of use of certain items, and so on. 

This request is to add equivalent field to the CompletionItem structure therefore allowing use of preselection in VS Code from language servers as it is possible from the regular completion provider.

The respective Node LS issue is https://github.com/Microsoft/vscode-languageserver-node/issues/371


