### PR TITLE
Fix minor typo in specification

### DIFF
--- a/specification.md
+++ b/specification.md
@@ -594,7 +594,7 @@ interface TextDocumentPositionParams {
 
 #### DocumentFilter
 
-A document filter denotes a document through properties like `language`, `schema` or `pattern`. An example is a filter that applies to TypeScript files on disk. Another example is a filter the applies to JSON files with name `package.json`:
+A document filter denotes a document through properties like `language`, `scheme` or `pattern`. An example is a filter that applies to TypeScript files on disk. Another example is a filter the applies to JSON files with name `package.json`:
 ```typescript
 { language: 'typescript', scheme: 'file' }
 { language: 'json', pattern: '**/package.json' }


### PR DESCRIPTION
Specification description mentions member "schema", even though examples and typescript spec mention member "scheme".