### PR TITLE
Add hierarchicalDocumentSymbolSupport to Text Document Client Capabilities

### DIFF
--- a/specification.md
+++ b/specification.md
@@ -1051,6 +1051,11 @@ export interface TextDocumentClientCapabilities {
 			 */
 			valueSet?: SymbolKind[];
 		}
+		
+		/**
+		 * Whether document symbol supports hierarchical `DocumentSymbol`s.
+		 */
+		hierarchicalDocumentSymbolSupport?: boolean;
 	};
 
 	/**

--- a/specification.md
+++ b/specification.md
@@ -1053,7 +1053,7 @@ export interface TextDocumentClientCapabilities {
 		}
 		
 		/**
-		 * Whether document symbol supports hierarchical `DocumentSymbol`s.
+		 * The client support hierarchical document symbols.
 		 */
 		hierarchicalDocumentSymbolSupport?: boolean;
 	};


### PR DESCRIPTION
This is already returned by the VS Code insiders build and in https://github.com/Microsoft/vscode-languageserver-node/blob/451eee78181d529cfa98ffc7198e2955cdfdc451/protocol/src/protocol.ts#L425.
It seems necessary in order to maintain backwards compatibility with clients that do not yet support the new `DocumentSymbol` type.