### PR TITLE
Fix formatting for folding API

### DIFF
--- a/specification.md
+++ b/specification.md
@@ -3870,8 +3870,8 @@ export interface FoldingRangeRequestParam {
 
 _Response_:
 * result: `FoldingRange[] | null` defined as follows:
-```ts
 
+```typescript
 /**
  * Enum of known range kinds
  */
@@ -3923,6 +3923,7 @@ export interface FoldingRange {
 	kind?: string;
 }
 ```
+
 * error: code and message set in case an exception happens during the 'textDocument/foldingRanges' request
 
 ### <a name="changeLog" class="anchor"></a>Change Log


### PR DESCRIPTION
The [section for the folding AP](https://microsoft.github.io/language-server-protocol/specification#textDocument_foldingRange) is formatted incorrectly at the moment.