### PR TITLE
Renamed FoldingRangeRequestParam => FoldingRangeParams

### DIFF
--- a/specification.md
+++ b/specification.md
@@ -3876,10 +3876,10 @@ The folding range request is sent from the client to the server to return all fo
 _Request_:
 
 * method: 'textDocument/foldingRange'
-* params: `FoldingRangeRequestParam` defined as follows
+* params: `FoldingRangeParams` defined as follows
 
 ```typescript
-export interface FoldingRangeRequestParam {
+export interface FoldingRangeParams {
 	/**
 	 * The text document.
 	 */


### PR DESCRIPTION
For all other requests, the single parameter type is named `...Params`. For consistency, this pattern should also apply to the new folding range request.