### PR TITLE
Add version information to the specification

### DIFF
--- a/specification.md
+++ b/specification.md
@@ -3988,11 +3988,11 @@ export interface FoldingRange {
 
 ### <a name="changeLog" class="anchor"></a>Change Log
 
-#### <a name="version_3_12_0" class="anchor"></a>3.10.0 (8/23/2018)
+#### <a name="version_3_12_0" class="anchor"></a>3.12.0 (8/23/2018)
 
 * Add support for `textDocument/prepareRename` request.
 
-#### <a name="version_3_11_0" class="anchor"></a>3.10.0 (8/21/2018)
+#### <a name="version_3_11_0" class="anchor"></a>3.11.0 (8/21/2018)
 
 * Add support for CodeActionOptions to allow a server to provide a list of code action it supports.
 

--- a/specification.md
+++ b/specification.md
@@ -3895,6 +3895,8 @@ export interface RenameRegistrationOptions extends TextDocumentRegistrationOptio
 
 #### <a name="textDocument_prepareRename" class="anchor"></a>Prepare Rename Request (:leftwards_arrow_with_hook:)
 
+> *Since version 3.12.0*
+
 The prepare rename request is sent from the client to the server to setup and test the validity of a rename operation at a given location.
 
 _Request_:


### PR DESCRIPTION
Fixed some typos and noted that `textDocument/prepareRename` is a new 3.12.0 feature.