### PR TITLE
Allow MarkupContent[] to be used as Hover contents

### DIFF
--- a/specification.md
+++ b/specification.md
@@ -3038,7 +3038,7 @@ interface Hover {
 	/**
 	 * The hover's content
 	 */
-	contents: MarkedString | MarkedString[] | MarkupContent;
+	contents: MarkedString | MarkedString[] | MarkupContent | MarkupContent[];
 
 	/**
 	 * An optional range is a range inside a text document


### PR DESCRIPTION
Fixes #518 and Microsoft/vscode-languageserver-node#374.

Supported by Microsoft/vscode-languageserver-node#417