### PR TITLE
overview: Fix example response id

### DIFF
--- a/overview.md
+++ b/overview.md
@@ -55,7 +55,7 @@ This is the response:
 ```json
 {
     "jsonrpc": "2.0",
-    "id": "1",
+    "id": 1,
     "result": {
         "uri": "file:///p%3A/mseng/VSCode/Playgrounds/cpp/provide.cpp",
         "range": {


### PR DESCRIPTION
The `id` field in JSON-RPC is numeric (matching the type in the request)