### PR TITLE
Add server capability for potential commit characters

### DIFF
--- a/specification.md
+++ b/specification.md
@@ -1531,6 +1531,11 @@ export interface CompletionOptions {
 	 * The characters that trigger completion automatically.
 	 */
 	triggerCharacters?: string[];
+
+	/**
+	 * The list of all possible completion commit characters
+	 */
+	potentialCommitCharacters?: string[];
 }
 /**
  * Signature help options.

--- a/specification.md
+++ b/specification.md
@@ -1535,7 +1535,7 @@ export interface CompletionOptions {
 	/**
 	 * The list of all possible completion commit characters
 	 */
-	potentialCommitCharacters?: string[];
+	allCommitCharacters?: string[];
 }
 /**
  * Signature help options.


### PR DESCRIPTION
Closes #527 

This PR adds a capability to the server that advertises the potential commit characters that can be used. This is useful so that clients can optimize their typing code by limiting the set of characters that could potentially cause a commit.