### PR TITLE
Update MS python-language-server repo

### DIFF
--- a/_implementors/servers.md
+++ b/_implementors/servers.md
@@ -62,7 +62,7 @@ index: 1
 | Puppet| [Lingua Pupuli](https://github.com/lingua-pupuli) | [puppet language server](https://github.com/lingua-pupuli/puppet-editor-services) |
 | Python| [Fabio Zadrozny](https://github.com/fabioz/) | [PyDev on VSCode](http://www.pydev.org/vscode/index.html) |
 | Python| [Palantir Technologies](https://github.com/palantir) | [python-language-server](https://github.com/palantir/python-language-server) |
-| Python | MS | [Python Tools for Visual Studio](https://github.com/Microsoft/PTVS)
+| Python | MS | [python-language-server](https://github.com/Microsoft/python-language-server)
 | R | [REditorSupport](https://github.com/REditorSupport) | [R language server](https://github.com/REditorSupport/languageserver) |
 | RAML | [RAML Workgroup](http://raml.org/about/workgroup) | [raml-language-server](https://github.com/raml-org/raml-language-server) Work in Progress |
 | ReasonML| [Jared Forsyth](https://github.com/jaredly) | [reason-language-server](https://github.com/jaredly/reason-language-server)


### PR DESCRIPTION
The language server was split out from PTVS a couple months ago.