### PR TITLE
Add Nim to the list of language identifiers

### DIFF
--- a/specification.md
+++ b/specification.md
@@ -643,6 +643,7 @@ Less | `less`
 Lua | `lua`
 Makefile | `makefile`
 Markdown | `markdown`
+Nim | `nim`
 Objective-C | `objective-c`
 Objective-C++ | `objective-cpp`
 Perl | `perl` and `perl6`


### PR DESCRIPTION
Now that the Nim programming language has an early stages, but working, language server I think it's time to add it to the list of identifiers.