### PR TITLE
Add Scala language identifier

### DIFF
--- a/specification.md
+++ b/specification.md
@@ -655,6 +655,7 @@ Razor (cshtml) | `razor`
 Ruby | `ruby`
 Rust | `rust`
 Sass | `scss` (syntax using curly brackets), `sass` (indented syntax)
+Scala | `scala`
 ShaderLab | `shaderlab`
 Shell Script (Bash) | `shellscript`
 SQL | `sql`


### PR DESCRIPTION
Not sure if this addition has meaningful consequences, but it seemed missing so here it is.