### PR TITLE
Fix TypeDefinitionResult.label typo in LSIF spec

### DIFF
--- a/indexFormat/specification.md
+++ b/indexFormat/specification.md
@@ -481,7 +481,7 @@ The corresponding `TypeDefinitionResult` looks like this:
 ```typescript
 interface TypeDefinitionResult {
 
-  label: `typeDefinition`
+  label: `typeDefinitionResult`
 
   result: (RangeId | lsp.Location)[];
 }


### PR DESCRIPTION
The included example below also has the missing *Result*:
```js
{ id: 37, type: "vertex", label: "typeDefinitionResult", result: 7 }
```