### PR TITLE
Add optional reason for why the client failed to apply an edit

### DIFF
--- a/specification.md
+++ b/specification.md
@@ -2417,6 +2417,14 @@ export interface ApplyWorkspaceEditResponse {
 	 * Indicates whether the edit was applied or not.
 	 */
 	applied: boolean;
+	
+	/**
+	 * A optional textual description for why the edit was not applied.
+	 * This may be used may be used by the server for diagnostic
+	 * logging or to provide a suitable error for a request that
+	 * triggered the edit.
+	 */
+	failureReason?: string;
 }
 ```
 * error: code and message set in case an exception happens during the request.

--- a/specification.md
+++ b/specification.md
@@ -2419,7 +2419,7 @@ export interface ApplyWorkspaceEditResponse {
 	applied: boolean;
 	
 	/**
-	 * A optional textual description for why the edit was not applied.
+	 * An optional textual description for why the edit was not applied.
 	 * This may be used may be used by the server for diagnostic
 	 * logging or to provide a suitable error for a request that
 	 * triggered the edit.


### PR DESCRIPTION
Fixes #618.

@dbaeumer I don't know if this is all that's required, or if my description is good enough - but feel free to suggest changes and/or tweak.

(It'd also be good for VS Code to use this too, for example describing a version mismatch if that's the reason it rejects edits).