### PR TITLE
Remove duplicated label property

### DIFF
--- a/specification.md
+++ b/specification.md
@@ -3234,12 +3234,6 @@ interface ParameterInformation {
 	label: string | [number, number];
 
 	/**
-	 * The label of this parameter. Will be shown in
-	 * the UI.
-	 */
-	label: string;
-
-	/**
 	 * The human-readable doc-comment of this parameter. Will be shown
 	 * in the UI but can be omitted.
 	 */


### PR DESCRIPTION
3854f1c503b3e1f1cab9b4f81e62fc47bc7d174a duplicated the `label` property in `ParameterInformation`. Since its type is `string | [number, number]`, I'm assuming the previous one of type `string` can be removed.