### PR TITLE
List Perl 5 and Perl 6 identifiers separately

### DIFF
--- a/specification.md
+++ b/specification.md
@@ -683,7 +683,8 @@ Makefile | `makefile`
 Markdown | `markdown`
 Objective-C | `objective-c`
 Objective-C++ | `objective-cpp`
-Perl | `perl` and `perl6`
+Perl | `perl`
+Perl 6 | `perl6`
 PHP | `php`
 Powershell | `powershell`
 Pug | `jade`


### PR DESCRIPTION
Perl 6 is a different language to Perl 5, with a confusing name.