### PR TITLE
Fix number of references example in LSIF spec

### DIFF
--- a/indexFormat/specification.md
+++ b/indexFormat/specification.md
@@ -410,7 +410,7 @@ let b: B;
 b.foo();
 ```
 
-Searching for `I#foo()` finds 5 references, searching for `II#foo()` finds 3 reference, and searching on `B#foo()` finds 6 results. The interesting part here is when the declaration of `class B` gets processed which implements `I` and `II`, neither the reference result bound to `I#foo()` nor the one bound to `II#foo()` can be reused. So we need to create a new one. To still be able to profit from the results generated for `I#foo` and `II#foo`, the LSIF supports nested references results. This way the one referenced from `B#foo` will reuse the one from `I#foo` and `II#foo`. Depending on how these declarations are parsed, the two reference results might contain the same references. When a language server interprets reference results consisting of other reference results, the server is responsible to de-dup the final ranges.
+Searching for `I#foo()` finds 4 references, searching for `II#foo()` finds 3 reference, and searching on `B#foo()` finds 5 results. The interesting part here is when the declaration of `class B` gets processed which implements `I` and `II`, neither the reference result bound to `I#foo()` nor the one bound to `II#foo()` can be reused. So we need to create a new one. To still be able to profit from the results generated for `I#foo` and `II#foo`, the LSIF supports nested references results. This way the one referenced from `B#foo` will reuse the one from `I#foo` and `II#foo`. Depending on how these declarations are parsed, the two reference results might contain the same references. When a language server interprets reference results consisting of other reference results, the server is responsible to de-dup the final ranges.
 
 In the above example, there will be three reference results
 


### PR DESCRIPTION
This PR updates the number of references for `I#foo()` and `B#foo()` in the example elaborated for `referenceResults`