### PR TITLE
Add missing declarationProvider field into server's capabilities

### DIFF
--- a/specification.md
+++ b/specification.md
@@ -1866,6 +1866,12 @@ interface ServerCapabilities {
 	 */
 	foldingRangeProvider?: boolean | FoldingRangeProviderOptions | (FoldingRangeProviderOptions & TextDocumentRegistrationOptions & StaticRegistrationOptions);
 	/**
+	 * The server provides go to declaration support.
+	 *
+	 * Since 3.14.0
+	 */
+	declarationProvider?: boolean | (TextDocumentRegistrationOptions & StaticRegistrationOptions);
+	/**
 	 * The server provides execute command support.
 	 */
 	executeCommandProvider?: ExecuteCommandOptions;


### PR DESCRIPTION
It seems like the `declarationProvider` field was forgotten when updating the protocol to 3.14.0. It exists in the [Microsoft/vscode-languageserver-node repository](https://github.com/Microsoft/vscode-languageserver-node/blob/dbfd37e35953ad0ee14c4eeced8cfbc41697b47e/protocol/src/protocol.declaration.ts#L38-L43) so I don't see why it shouldn't exist here.

This should close #673.