### PR TITLE
Fix contents key name in LSIF spec

### DIFF
--- a/indexFormat/specification.md
+++ b/indexFormat/specification.md
@@ -791,7 +791,7 @@ The project vertex may include additional properties where they are applicable a
 
 ## Embedding content
 
-It can be valuable to embed the content of a document or project file into the dump as well. For example, if the content of the document is a virtual document generated from program meta data. The index format therefore supports an optional `content` property on the `document` and `project` vertex. If used the content needs to be `base64` encoded.
+It can be valuable to embed the content of a document or project file into the dump as well. For example, if the content of the document is a virtual document generated from program meta data. The index format therefore supports an optional `contents` property on the `document` and `project` vertex. If used the content needs to be `base64` encoded.
 
 ## Project exports and external imports
 


### PR DESCRIPTION
This PR changes the key name of contents to comply with what `lsif-typescript` generates. (cc @dbaeumer)