### PR TITLE
Adds LSIF implementation guide

### DIFF
--- a/indexFormat/implementation.md
+++ b/indexFormat/implementation.md
@@ -1,12 +1,12 @@
 # Building an LSIF exporter
 
-With an LSIF (Language Server Index Format) exporter for your programming language of choice, you can use [Rich Code Navigation](https://code.visualstudio.com/blogs/2018/12/04/rich-navigation) on pull requests inside Visual Studio and Visual Studio Code.
+With an LSIF (Language Server Index Format) exporter for your programming language of choice, you can use [Rich Code Navigation](https://code.visualstudio.com/blogs/2018/12/04/rich-navigation) on pull requests inside Visual Studio and Visual Studio Code. Users can navigate PRs with go-to-definition, find-all-references, and diagnostics, without requiring a local checkout.
 
 In this guide, we cover how you can build an LSIF implementation that can be used for Rich Code Navigation. If you are new to LSIF, start with the [specification](specification.md), which covers motivation and implementation details of the protocol.
 
 ## The Rich Code Navigation scenario
 
-With Rich Code Navigation, users use navigate features (peek definition, find all references, diagnostics, etc.) over PRs in their editor without having a local checkout. These navigation features are powered by a cloud language service, which uses an LSIF index. The index can be generated at a variety of places, like for instance in the CI pipeline:
+With Rich Code Navigation, users use navigate features (peek definition, find all references, diagnostics, etc.) over PRs in their editor without having a local checkout. These navigation features are powered by a cloud language service, which uses an LSIF index. The index can be generated at a variety of places. For example, the index could be generated in a CI pipeline with the following steps:
 
 1. User creates a new PR.
 1. The CI configured on the repo builds the PR.
@@ -28,17 +28,19 @@ As [detailed in the spec](specification.md#project-exports-and-external-imports)
 
 ### Index exporter
 
-This tool generates an LSIF dump for a workspace by traversing through source files and storing LSP responses. For TypeScript/JavaScript, [`lsif-tsc`](https://github.com/Microsoft/lsif-node/tree/master/tsc) is the index exporter.
+The index exporter generates an LSIF dump for a workspace by traversing through source files and storing LSP responses. For TypeScript/JavaScript, [`lsif-tsc`](https://github.com/Microsoft/lsif-node/tree/master/tsc) is the index exporter.
 
 ### Package linker
 
-This tool ingests the LSIF output from an index exporter and converts `moniker` vertices into the package manager scheme. Additionally, it links these monikers to `packageInformation` vertices that reference packages hosted on a registry. For TypeScript/JavaScript, [`lsif-npm`](https://github.com/Microsoft/lsif-node/tree/master/npm) is the package manager linker for NPM.
+The package linker converts the LSIF output of the index exporter into a global friendly index. By using package metadata, export `moniker` vertices are linked to packages available on a registry. For instance, the `observable` export from the mobx dependency is linked to the mobx dependency available on NPM. The package metadata is used to create the `packageInformation` vertices that reference external packages.
+
+For TypeScript/JavaScript, [`lsif-npm`](https://github.com/Microsoft/lsif-node/tree/master/npm) is the package manager linker for NPM.
 
 ## Testing and validation
 
 ### LSIF validation utility
 
-The [`lsif-util`](https://github.com/jumattos/lsif-util) tool can validate your generated LSIF output. Additionally, the tool can also help you comprehend the generated output by visualizing and searching the vertices and edges.
+The [`lsif-util`](https://github.com/jumattos/lsif-util) tool can validate your generated LSIF output. Additionally, the tool can also be used to search the output and visualize via Graphviz.
 
 ### VS Code LSIF extension
 
@@ -54,7 +56,7 @@ If the LSIF exporter does not work across platforms (Windows, Linux, Mac), platf
 
 ### `--outputFormat` execution flag
 
-It is recommended that the LSIF exporter support two output formats: `line` and `json`.
+It is recommended that the LSIF exporter support two output formats: `line` and `json`. The `line` format is required for an integration with Rich Code Navigation.
 
 1. `line`: Output is a series of JSON objects (vertex or edge) separated by newline. This format is optimized for streaming output, and works better for larger repos.
 1. `json`: Output is a valid JSON array, with each JSON object (vertex or edge) as an element of this array. The VS Code LSIF extension uses this format.
@@ -62,6 +64,10 @@ It is recommended that the LSIF exporter support two output formats: `line` and 
 ### `--projectRoot` execution flag
 
 This flag can be used to specify the root of the project directory, or specify the location of the project configuration file (`tsconfig.json` for TypeScript projects).
+
+### Required documentation
+
+Since LSIF is an evolving protocol, it is critical to document which version of LSIF is being supported by the exporter.
 
 ## Support
 

--- a/indexFormat/implementation.md
+++ b/indexFormat/implementation.md
@@ -50,6 +50,19 @@ With the [LSIF extension for VS Code](https://github.com/Microsoft/vscode-lsif-e
 
 We have seen the following patterns work well in existing implementations.
 
+### Method checklist
+
+For an ideal integration with Rich Code Navigation, the following methods are required. For some languages, methods such as `textDocument/declaration` might not be applicable.
+
+- [ ] `textDocument/hover`
+- [ ] `textDocument/definition`
+- [ ] `textDocument/references`
+- [ ] `textDocument/implementation`
+- [ ] `textDocument/declaration`
+- [ ] `textDocument/typeDefinition`
+- [ ] `textDocument/diagnostic`
+- [ ] Cross-repo navigation for dependencies
+
 ### Cross-platform
 
 If the LSIF exporter does not work across platforms (Windows, Linux, Mac), platform dependencies should be called out.

--- a/indexFormat/implementation.md
+++ b/indexFormat/implementation.md
@@ -1,0 +1,78 @@
+# Building an LSIF exporter
+
+By building an LSIF (Language Server Index Format) exporter for your language server, users can use [Rich Code Navigation](https://code.visualstudio.com/blogs/2018/12/04/rich-navigation) on their pull requests.
+
+If you are new to LSIF, [the specification page](specification.md) covers the motivation and implementation details of the protocol.
+
+In this guide, we cover how an LSIF implementation can be used in the context of Rich Code Navigation.
+
+## Rich Code Navigation scenario
+
+With Rich Code Navigation, users can use navigation features on their pull requests, without requiring a local checkout. In this scenario, the navigation features are powered through an external service. This service uses a pre-built LSIF index. The index can be generated at a variety of places, like for instance the CI pipeline of the repo:
+
+1. User creates a pull request
+1. The CI tool builds this pull request
+1. The LSIF exporter runs in the CI pipeline and generates the LSIF file
+
+## LSIF exporter implementations
+
+| Language | Repository |
+|--|--|
+| TypeScript/JavaScript | [lsif-node](https://github.com/Microsoft/lsif-node) |
+
+> Are we missing an implementation? Create a new issue on GitHub.
+
+## LSIF implementation skeleton
+
+As detailed in the specification, the LSIF exporter consists of two tools: the index exporter and the package manager linker.
+
+### Index exporter
+
+This tool generates an LSIF dump for a workspace by traversing through source files and storing LSP responses. For TypeScript/JavaScript, [`lsif-tsc`](https://github.com/Microsoft/lsif-node/tree/master/tsc) is the index exporter.
+
+### Package manager linker
+
+This tool ingests the LSIF output from an index exporter and converts `moniker` vertices into the package manager scheme. Additionally, it links these monikers to `packageInformation` vertices. For TypeScript/JavaScript, [`lsif-npm`](https://github.com/Microsoft/lsif-node/tree/master/npm) is the package manager linker for NPM.
+
+## Testing and validation
+
+### lsif-util
+
+The `lsif-util` tool can validate your generated LSIF output. Additionally, the tool can also help you comprehend the generated output by visualizing and searching the vertices and edges.
+
+### VS Code LSIF extension
+
+With the [LSIF extension for VS Code](https://github.com/Microsoft/vscode-lsif-extension), you can power navigation in the editor over a generated LSIF file, instead of running a language server.
+
+## Recommended patterns
+
+### Execution from CLI
+
+asdf
+
+### `--outputFormat` flag
+
+1. `json`: Output is a JSON array, with each JSON object (vertex or edge) as an element of this array.
+1. `line`: Output is a series of lines, each line is a vertex or an edge. This format is more friendly to streaming output, and therefore preferred.
+
+## `--projectRoot flag`
+
+asdf
+
+## Packaging
+
+## Checklist
+
+- [ ] Required documentation: usage instructions
+- [ ] Required documentation: platform dependencies
+- [ ] 
+
+Performance
+
+## Integration with Rich Code Navigation
+
+While we 
+
+## Support
+
+Feel free to reach out to us for questions by raising an issue on GitHub.

--- a/indexFormat/implementation.md
+++ b/indexFormat/implementation.md
@@ -1,77 +1,67 @@
 # Building an LSIF exporter
 
-By building an LSIF (Language Server Index Format) exporter for your language server, users can use [Rich Code Navigation](https://code.visualstudio.com/blogs/2018/12/04/rich-navigation) on their pull requests.
+With an LSIF (Language Server Index Format) exporter for your programming language of choice, you can use [Rich Code Navigation](https://code.visualstudio.com/blogs/2018/12/04/rich-navigation) on pull requests inside Visual Studio and Visual Studio Code.
 
-If you are new to LSIF, [the specification page](specification.md) covers the motivation and implementation details of the protocol.
+In this guide, we cover how you can build an LSIF implementation that can be used for Rich Code Navigation. If you are new to LSIF, start with the [specification](specification.md), which covers motivation and implementation details of the protocol.
 
-In this guide, we cover how an LSIF implementation can be used in the context of Rich Code Navigation.
+## The Rich Code Navigation scenario
 
-## Rich Code Navigation scenario
+With Rich Code Navigation, users use navigate features (peek definition, find all references, diagnostics, etc.) over PRs in their editor without having a local checkout. These navigation features are powered by a cloud language service, which uses an LSIF index. The index can be generated at a variety of places, like for instance in the CI pipeline:
 
-With Rich Code Navigation, users can use navigation features on their pull requests, without requiring a local checkout. In this scenario, the navigation features are powered through an external service. This service uses a pre-built LSIF index. The index can be generated at a variety of places, like for instance the CI pipeline of the repo:
+1. User creates a new PR.
+1. The CI configured on the repo builds the PR.
+1. The LSIF exporter runs on CI and generates the LSIF index.
 
-1. User creates a pull request
-1. The CI tool builds this pull request
-1. The LSIF exporter runs in the CI pipeline and generates the LSIF file
-
-## LSIF exporter implementations
+## LSIF exporters
 
 | Language | Repository |
 |--|--|
 | TypeScript/JavaScript | [lsif-node](https://github.com/Microsoft/lsif-node) |
+| Java | |
+| C# | |
 
-> Are we missing an implementation? Create a new issue on GitHub.
+> Are we missing an implementation? File a new issue on GitHub to add it here.
 
-## LSIF implementation skeleton
+## LSIF exporter skeleton
 
-As detailed in the specification, the LSIF exporter consists of two tools: the index exporter and the package manager linker.
+As [detailed in the spec](specification.md#project-exports-and-external-imports), the LSIF exporter consists of two tools: the index exporter and the package linker.
 
 ### Index exporter
 
 This tool generates an LSIF dump for a workspace by traversing through source files and storing LSP responses. For TypeScript/JavaScript, [`lsif-tsc`](https://github.com/Microsoft/lsif-node/tree/master/tsc) is the index exporter.
 
-### Package manager linker
+### Package linker
 
-This tool ingests the LSIF output from an index exporter and converts `moniker` vertices into the package manager scheme. Additionally, it links these monikers to `packageInformation` vertices. For TypeScript/JavaScript, [`lsif-npm`](https://github.com/Microsoft/lsif-node/tree/master/npm) is the package manager linker for NPM.
+This tool ingests the LSIF output from an index exporter and converts `moniker` vertices into the package manager scheme. Additionally, it links these monikers to `packageInformation` vertices that reference packages hosted on a registry. For TypeScript/JavaScript, [`lsif-npm`](https://github.com/Microsoft/lsif-node/tree/master/npm) is the package manager linker for NPM.
 
 ## Testing and validation
 
-### lsif-util
+### LSIF validation utility
 
-The `lsif-util` tool can validate your generated LSIF output. Additionally, the tool can also help you comprehend the generated output by visualizing and searching the vertices and edges.
+The [`lsif-util`](https://github.com/jumattos/lsif-util) tool can validate your generated LSIF output. Additionally, the tool can also help you comprehend the generated output by visualizing and searching the vertices and edges.
 
 ### VS Code LSIF extension
 
-With the [LSIF extension for VS Code](https://github.com/Microsoft/vscode-lsif-extension), you can power navigation in the editor over a generated LSIF file, instead of running a language server.
+With the [LSIF extension for VS Code](https://github.com/Microsoft/vscode-lsif-extension), you can dogfood an LSIF index to power navigation inside VS Code.
 
 ## Recommended patterns
 
-### Execution from CLI
+We have seen the following patterns work well in existing implementations.
 
-asdf
+### Cross-platform
 
-### `--outputFormat` flag
+If the LSIF exporter does not work across platforms (Windows, Linux, Mac), platform dependencies should be called out.
 
-1. `json`: Output is a JSON array, with each JSON object (vertex or edge) as an element of this array.
-1. `line`: Output is a series of lines, each line is a vertex or an edge. This format is more friendly to streaming output, and therefore preferred.
+### `--outputFormat` execution flag
 
-## `--projectRoot flag`
+It is recommended that the LSIF exporter support two output formats: `line` and `json`.
 
-asdf
+1. `line`: Output is a series of JSON objects (vertex or edge) separated by newline. This format is optimized for streaming output, and works better for larger repos.
+1. `json`: Output is a valid JSON array, with each JSON object (vertex or edge) as an element of this array. The VS Code LSIF extension uses this format.
 
-## Packaging
+### `--projectRoot` execution flag
 
-## Checklist
-
-- [ ] Required documentation: usage instructions
-- [ ] Required documentation: platform dependencies
-- [ ] 
-
-Performance
-
-## Integration with Rich Code Navigation
-
-While we 
+This flag can be used to specify the root of the project directory, or specify the location of the project configuration file (`tsconfig.json` for TypeScript projects).
 
 ## Support
 


### PR DESCRIPTION
This PR introduces a new doc for LSIF implementors, based on feedback from developers working on LSIF. Just like the language server world has a [specification](https://microsoft.github.io/language-server-protocol/specification) and [a guide for language extensions](https://code.visualstudio.com/api/language-extensions/language-server-extension-guide), the idea is to introduce a guide that complements the spec. The goal of this guide is to walk through the developer workflow for building an LSIF exporter.

In this review, I want to bring attention to and get your feedback on:

* The choice of terminology: "LSIF exporter", 2 tools inside the LSIF exporter: "index exporter" (`lsif-tsc`) and "package linker" (`lsif-npm`)
* Details around the rich code navigation scenario (too much/too little?)
* The "recommended patterns" section that details out common implementation details that we have seen so far: do we need a better "API" definition for LSIF exporters?
