### PR TITLE
Fix #758 Change LocationLink's targetUri to be a DocumentUri

### DIFF
--- a/specification.md
+++ b/specification.md
@@ -309,7 +309,7 @@ interface LocationLink {
 	/**
 	 * The target resource identifier of this link.
 	 */
-	targetUri: string;
+	targetUri: DocumentUri;
 
 	/**
 	 * The full target range of this link. If the target for example is a symbol then target range is the


### PR DESCRIPTION
The target URI of a `LocationLink` should be a URI and not just any random string.