### PR TITLE
Add Spyder IDE to list of LSP supporting tools

### DIFF
--- a/_implementors/tools.md
+++ b/_implementors/tools.md
@@ -32,6 +32,7 @@ index: 2
 | [Kakoune](http://kakoune.org/) | [ul](https://github.com/ul) | [kak-lsp](https://github.com/ul/kak-lsp) |
 | [Sublime Text](https://www.sublimetext.com/) | [Tom van Ommeren](https://github.com/tomv564) | [lsp](https://github.com/tomv564/LSP) |
 | [Multiple editors](https://github.com/Valloric/ycmd#known-ycmd-clients) | Ycmd team | [ycmd](https://github.com/Valloric/ycmd) | 
-| [Brackets](http://brackets.io) | [Adobe](https://github.com/adobe) | [brackets](https://github.com/adobe/brackets) | 
-| [Cloud Studio](https://studio.dev.tencent.com/) | CODING |  | 
+| [Brackets](http://brackets.io) | [Adobe](https://github.com/adobe) | [brackets](https://github.com/adobe/brackets) |
+| [Cloud Studio](https://studio.dev.tencent.com/) | CODING |  |
+| [Spyder](http://spyder-ide.org) | [Spyder Dev Team](https://github.com/spyder-ide) | [spyder](https://github.com/spyder-ide/spyder) | 
 {: .table .table-bordered .table-responsive}


### PR DESCRIPTION
We've added LSP support from Spyder 4.0 beta2 onwards.