### PR TITLE
Remove "non-empty string" comment for workspace/symbol

### DIFF
--- a/specification.md
+++ b/specification.md
@@ -2449,7 +2449,8 @@ _Request_:
  */
 interface WorkspaceSymbolParams {
 	/**
-	 * A non-empty query string
+	 * A query string to filter symbols by. Clients may send an empty
+	 * string here to request all symbols.
 	 */
 	query: string;
 }


### PR DESCRIPTION
VS Code sends empty strings to LSP servers here to get a full symbol list. Based on discussion at https://github.com/microsoft/vscode-languageserver-node/issues/458 I believe that the VS Code behaviour is desired and the spec is incorrect (the original intention was designed to avoid clients accidentally requesting all symbols before the user had typed, but it seems leaving that to the server is the best option).