### PR TITLE
Fixed dead links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 The Language Server Protocol is now available through its own [website](https://microsoft.github.io/language-server-protocol/). 
 The website contains information about :
 * How the protocol [works](https://microsoft.github.io/language-server-protocol/overview)
-* A better readable [specification](https://microsoft.github.io/language-server-protocol/specification)
+* A better readable [specification](https://microsoft.github.io/language-server-protocol/specifications/specification-3-14/)
 * Documents about protocol [implementations](https://microsoft.github.io/language-server-protocol/implementors/servers/).
 
 ## Contributing
-If you are interested in fixing issues like typos you can either file an issue or provide a pull request containing the changes to the [specification file](https://github.com/Microsoft/language-server-protocol/blob/gh-pages/specification.md). 
+If you are interested in fixing issues like typos you can either file an issue or provide a pull request containing the changes to the relevant [specification file](https://github.com/microsoft/language-server-protocol/tree/gh-pages/_specifications).
 
 When proposing an extension to the specification, then please refer to the [How to Contribute to the Language Server Protocol](contributing.md) document.
 
@@ -15,7 +15,7 @@ This project has adopted the [Microsoft Open Source Code of Conduct](https://ope
 
 ## The Language Server Protocol
 
-See the [Web site](https://microsoft.github.io/language-server-protocol/specification)
+See the [Web site](https://microsoft.github.io/language-server-protocol/specifications/specification-3-14/)
 
 ## License
 [Creative Commons Attribution / MIT](License.txt)


### PR DESCRIPTION
The links changed led to 404's either on GitHub or the LSP's website, so I changed them to appropriate working links.