### PR TITLE
Removed duplicate foldingRangeProvider field in ServerCapabilities

### DIFF
--- a/specification.md
+++ b/specification.md
@@ -1701,13 +1701,6 @@ interface ServerCapabilities {
 	foldingRangeProvider?: boolean | FoldingRangeOptions | FoldingRangeRegistrationOptions;
 
 	/**
-	 * The server provides folding provider support.
-	 *
-	 * @since 3.10.0
-	 */
-	foldingRangeProvider?: boolean | FoldingRangeOptions | FoldingRangeRegistrationOptions;
-
-	/**
 	 * The server provides execute command support.
 	 */
 	executeCommandProvider?: ExecuteCommandOptions;


### PR DESCRIPTION
Dear Good People at Microsoft LSP,

 I found a duplicate field for foldingRangeProvider which I removed. 

 I am working on a Go implementation and stumbled on it while defining data structures. This is my first pull request on this project - I did read the contributing guideline and code of conduct, and hopefully I didn't violate either!

Kind regards,
Dayo