### PR TITLE
Correct misuse of "then" where "than" is appropriate.

### DIFF
--- a/_specifications/specification-3-14.md
+++ b/_specifications/specification-3-14.md
@@ -43,7 +43,7 @@ The header part is encoded using the 'ascii' encoding. This includes the '\r\n' 
 
 ### Content Part
 
-Contains the actual content of the message. The content part of a message uses [JSON-RPC](http://www.jsonrpc.org/) to describe requests, responses and notifications. The content part is encoded using the charset provided in the Content-Type field. It defaults to `utf-8`, which is the only encoding supported right now. If a server or client receives a header with a different encoding then `utf-8` it should respond with an error.
+Contains the actual content of the message. The content part of a message uses [JSON-RPC](http://www.jsonrpc.org/) to describe requests, responses and notifications. The content part is encoded using the charset provided in the Content-Type field. It defaults to `utf-8`, which is the only encoding supported right now. If a server or client receives a header with a different encoding than `utf-8`, then it should respond with an error.
 
 (Prior versions of the protocol used the string constant `utf8` which is not a correct encoding constant according to [specification](http://www.iana.org/assignments/character-sets/character-sets.xhtml).) For backwards compatibility it is highly recommended that a client and a server treats the string `utf8` as `utf-8`.
 


### PR DESCRIPTION
The commit at the head of the gh-pages branch at the time of this writing says "different ... then" instead of "different ... than" inside of a conditional clause.  I have changed "then" to "than" and also made explicit the implicit "then" of the condition, though I am perfectly willing to allow the latter to remain implicit if people prefer that.