### PR TITLE
Correct a broken link to the canonical copy of a specification.

### DIFF
--- a/_specifications/specification-3-14.md
+++ b/_specifications/specification-3-14.md
@@ -15,7 +15,7 @@ This document describes version 3.14.x of the language server protocol. An imple
 The 2.x version of this document can be found [here](https://github.com/Microsoft/language-server-protocol/blob/master/versions/protocol-2-x.md).
 The 1.x version of this document can be found [here](https://github.com/Microsoft/language-server-protocol/blob/master/versions/protocol-1-x.md).
 
-**Note:** edits to this specification can be made via a pull request against this markdown [document](https://github.com/Microsoft/language-server-protocol/blob/gh-pages/specification.md).
+**Note:** edits to this specification can be made via a pull request against this markdown [document](https://github.com/Microsoft/language-server-protocol/blob/gh-pages/_specifications/specification-3-14.md).
 
 ## Base Protocol
 


### PR DESCRIPTION
See #868.