### PR TITLE
Adding Antlr LSP server.

### DIFF
--- a/_implementors/servers.md
+++ b/_implementors/servers.md
@@ -12,6 +12,7 @@ index: 1
 | Language | Maintainer | Repository | Implementation Language |
 |------|--------|----------|---------------|
 | Ada/SPARK | AdaCore |  [ada_language_server](https://github.com/AdaCore/ada_language_server) | Ada |
+| Antlr | [Ken Domino](https://github.com/kaby76) | [Antlrvsix](https://github.com/kaby76/AntlrVSIX) | C# |
 | [API Elements](http://api-elements.readthedocs.io/en/latest/) | [Vincenzo Chianese(@XVincentX)](https://github.com/XVincentX) | [vscode-apielements](https://github.com/XVincentX/vscode-apielements) | TypeScript |
 | Apache Camel | [Contributors](https://github.com/camel-tooling/camel-language-server/graphs/contributors) | [Apache Camel Language Server](https://github.com/camel-tooling/camel-language-server) | Java |
 | Apex | Salesforce |  [VS Code Apex extension](https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode-apex) | TypeScript |


### PR DESCRIPTION
I've added to the servers.md page my implementation for an Antlr LSP server. This server provides only basic functionality at the moment: initialize, initialized, open, hover, and goto def. However, the code for much of v3.14 LSP support is currently called in a standard VS IDE 2019 extension. It only needs to be called from the server itself. --Ken Domino