### PR TITLE
add Kate text editor, LSP plugin per default integrated since 19.12

### DIFF
--- a/_implementors/tools.md
+++ b/_implementors/tools.md
@@ -40,4 +40,5 @@ index: 2
 | [Aginity Pro](https://www.aginity.com/products/aginity-pro/) | [Aginity](https://www.aginity.com) | |
 | [Aginity Team](https://www.aginity.com/products/aginity-team/) | [Aginity](https://www.aginity.com) | |
 | [JupyterLab](https://github.com/jupyterlab/jupyterlab) | [krassowski](https://github.com/krassowski) | [jupyterlab-lsp](https://github.com/krassowski/jupyterlab-lsp) |
+| [Kate](https://kate-editor.org) | [Kate Team](https://kate-editor.org) | [kate](https://invent.kde.org/kde/kate) |
 {: .table .table-bordered .table-responsive}


### PR DESCRIPTION
add Kate text editor, LSP plugin per default integrated since 19.12.0 release

I added it to the back of the table, thought I think somebody should better sort this table somehow.

At the moment that neither looks sorted alphabetically nor for "popularity" (which would be hard to judge, but I would assume e.g. Atom would be more in the top and Kate would stay down ;=)