### PR TITLE
Drop extra ExecuteCommandOptions def in 3.15

### DIFF
--- a/_specifications/specification-3-15.md
+++ b/_specifications/specification-3-15.md
@@ -1639,16 +1639,6 @@ interface InitializeError {
 The server can signal the following capabilities:
 
 ```typescript
-/**
- * Execute command options.
- */
-export interface ExecuteCommandOptions {
-	/**
-	 * The commands to be executed on the server
-	 */
-	commands: string[]
-}
-
 interface ServerCapabilities {
 	/**
 	 * Defines how text documents are synced. Is either a detailed structure defining each notification or


### PR DESCRIPTION
We aready have `export interface ExecuteCommandOptions` (more precise) definition. Let's drop this one to avoid duplication.