### PR TITLE
Add workspaceFolders/configuration/window to 3.15

### DIFF
--- a/_specifications/specification-3-15.md
+++ b/_specifications/specification-3-15.md
@@ -1571,12 +1571,36 @@ interface ClientCapabilities {
 		* Capabilities specific to the `workspace/executeCommand` request.
 		*/
 		executeCommand?: ExecuteCommandClientCapabilities;
+
+		/**
+	 	* The client has support for workspace folders.
+	 	*
+		 * Since 3.6.0
+		 */
+		workspaceFolders?: boolean;
+
+		/**
+		 * The client supports `workspace/configuration` requests.
+		 *
+		 * Since 3.6.0
+		 */
+		configuration?: boolean;
 	};
 
 	/**
 	 * Text document specific client capabilities.
 	 */
 	textDocument?: TextDocumentClientCapabilities;
+
+	/**
+	 * Window specific client capabilities.
+	 */
+	window?: {
+		/**
+		 * Whether client supports handling progress notifications.
+		 */
+		workDoneProgress?: boolean;
+	}
 
 	/**
 	 * Experimental client capabilities.


### PR DESCRIPTION
It seems `workspaceFolders` and `configuration` properties were lost, but they are present in 3.14.
The `window` property is new in 3.15, let's add it to `ClientCapabilities` definition