### PR TITLE
Specify logTrace notification 

### DIFF
--- a/_specifications/specification-3-15.md
+++ b/_specifications/specification-3-15.md
@@ -1289,15 +1289,6 @@ export interface PartialResultParams {
 }
 ```
 
-#### <a href="#traceValue" name="traceValue" class="anchor"> TraceValue </a>
-
-A `TraceValue` represents the level of verbosity with which the server systematically reports its execution trace using [$/logTrace](#logTrace) notifications.
-The initial trace value is set by the client at initialization and can be modified later using the [$/setTrace](#setTrace) notification.
-
-```typescript
-export type TraceValue = 'off' | 'message' | 'verbose'
-```
-
 ### Actual Protocol
 
 This section documents the actual language server protocol. It uses the following format:
@@ -1388,7 +1379,7 @@ interface InitializeParams extends WorkDoneProgressParams {
 	/**
 	 * The initial trace setting. If omitted trace is disabled ('off').
 	 */
-	trace?: TraceValue;
+	trace?: 'off' | 'messages' | 'verbose';
 
 	/**
 	 * The workspace folders configured in the client when the server starts.
@@ -1862,51 +1853,6 @@ The server should exit with `success` code 0 if the shutdown request has been re
 _Notification_:
 * method: 'exit'
 * params: void
-
-#### <a href="#logTrace" name="logTrace" class="anchor">LogTrace Notification (:arrow_left:)</a>
-
-A notification to log the trace of the server's execution.
-The amount and content of these notifications depends on the current `trace` configuration.
-If `trace` is `'off'`, the server should not send any `logTrace` notification.
-If `trace` is `'message'`, the server should not add the `'verbose'` field in the `logTraceParams`.
-
-`$/logTrace` should be used for systematic trace reporting. For single debugging messages, the server should send [`window/logMessage`](#window_logMessage) notifications.
-
-
-_Notification_:
-* method: '$/logTrace'
-* params: `logTraceParams` defined as follows:
-
-```typescript
-interface logTraceParams {
-	/**
-	 * The message to be logged.
-	 */
-	message: string;
-
-	/**
-	 * Additional information that can be computed if the `trace` configuration is set to `'verbose'`
-	 */
-	verbose?: string;
-}
-```
-
-#### <a href="#setTrace" name="setTrace" class="anchor">SetTrace Notification (:arrow_right:)</a>
-
-A notification that should be used by the client to modify the trace setting of the server.
-
-_Notification_:
-* method: '$/setTrace'
-* params: `setTraceParams` defined as follows:
-
-```typescript
-interface setTraceParams {
-	/**
-	 * The new value that should be assigned to the trace setting.
-	 */
-	value: TraceValue;
-}
-```
 
 #### <a href="#window_showMessage" name="window_showMessage" class="anchor">ShowMessage Notification (:arrow_left:)</a>
 

--- a/_specifications/specification-3-15.md
+++ b/_specifications/specification-3-15.md
@@ -1861,7 +1861,8 @@ The amount and content of these notifications depends on the current `trace` con
 If `trace` is `'off'`, the server should not send any `logTrace` notification.
 If `trace` is `'message'`, the server should not add the `'verbose'` field in the `logTraceParams`.
 
-** Insert a sentence about the difference between logTrace and logMessage **
+`logTrace` should be used for systematic trace reporting. For single debugging messages, the server should send `window/logMessage` notifications.
+
 
 _Notification_:
 * method: 'logTrace'

--- a/_specifications/specification-3-15.md
+++ b/_specifications/specification-3-15.md
@@ -1854,6 +1854,33 @@ _Notification_:
 * method: 'exit'
 * params: void
 
+#### <a href="logTrace" name="logTrace" class="anchor">LogTrace Notification (:arrow_left:)</a>
+
+A notification to log the trace of the server's execution.
+The amount and content of these notifications depends on the current `trace` configuration.
+If `trace` is `'off'`, the server should not send any `logTrace` notification.
+If `trace` is `'message'`, the server should not add the `'verbose'` field in the `logTraceParams`.
+
+** Insert a sentence about the difference between logTrace and logMessage **
+
+_Notification_:
+* method: 'logTrace'
+* params: `logTraceParams` defined as follows:
+
+```typescript
+interface logTraceParams {
+	/**
+	 * The message to be logged.
+	 */
+	message: string;
+
+	/**
+	 * Additional information that can be computed if the `trace` configuration is set to `'verbose'`
+	 */
+	verbose?: string;
+}
+```
+
 #### <a href="#window_showMessage" name="window_showMessage" class="anchor">ShowMessage Notification (:arrow_left:)</a>
 
 The show message notification is sent from a server to a client to ask the client to display a particular message in the user interface.

--- a/_specifications/specification-3-15.md
+++ b/_specifications/specification-3-15.md
@@ -1289,6 +1289,15 @@ export interface PartialResultParams {
 }
 ```
 
+#### <a href="#traceValue" name="traceValue" class="anchor"> TraceValue </a>
+
+A `TraceValue` represents the level of verbosity with which the server systematically reports its execution trace using [$/logTrace](#logTrace) notifications.
+The initial trace value is set by the client at initialization and can be modified later using the [$/setTrace](#setTrace) notification.
+
+```typescript
+export type TraceValue = 'off' | 'message' | 'verbose'
+```
+
 ### Actual Protocol
 
 This section documents the actual language server protocol. It uses the following format:
@@ -1379,7 +1388,7 @@ interface InitializeParams extends WorkDoneProgressParams {
 	/**
 	 * The initial trace setting. If omitted trace is disabled ('off').
 	 */
-	trace?: 'off' | 'messages' | 'verbose';
+	trace?: TraceValue;
 
 	/**
 	 * The workspace folders configured in the client when the server starts.
@@ -1879,6 +1888,23 @@ interface logTraceParams {
 	 * Additional information that can be computed if the `trace` configuration is set to `'verbose'`
 	 */
 	verbose?: string;
+}
+```
+
+#### <a href="#setTrace" name="setTrace" class="anchor">SetTrace Notification (:arrow_right:)</a>
+
+A notification that should be used by the client to modify the trace setting of the server.
+
+_Notification_:
+* method: '$/setTrace'
+* params: `setTraceParams` defined as follows:
+
+```typescript
+interface setTraceParams {
+	/**
+	 * The new value that should be assigned to the trace setting.
+	 */
+	value: TraceValue;
 }
 ```
 

--- a/_specifications/specification-3-15.md
+++ b/_specifications/specification-3-15.md
@@ -1854,18 +1854,18 @@ _Notification_:
 * method: 'exit'
 * params: void
 
-#### <a href="logTrace" name="logTrace" class="anchor">LogTrace Notification (:arrow_left:)</a>
+#### <a href="#logTrace" name="logTrace" class="anchor">LogTrace Notification (:arrow_left:)</a>
 
 A notification to log the trace of the server's execution.
 The amount and content of these notifications depends on the current `trace` configuration.
 If `trace` is `'off'`, the server should not send any `logTrace` notification.
 If `trace` is `'message'`, the server should not add the `'verbose'` field in the `logTraceParams`.
 
-`logTrace` should be used for systematic trace reporting. For single debugging messages, the server should send `window/logMessage` notifications.
+`$/logTrace` should be used for systematic trace reporting. For single debugging messages, the server should send [`window/logMessage`](#window_logMessage) notifications.
 
 
 _Notification_:
-* method: 'logTrace'
+* method: '$/logTrace'
 * params: `logTraceParams` defined as follows:
 
 ```typescript

--- a/_specifications/specification-3-16.md
+++ b/_specifications/specification-3-16.md
@@ -1289,6 +1289,15 @@ export interface PartialResultParams {
 }
 ```
 
+#### <a href="#traceValue" name="traceValue" class="anchor"> TraceValue </a>
+
+A `TraceValue` represents the level of verbosity with which the server systematically reports its execution trace using [$/logTrace](#logTrace) notifications.
+The initial trace value is set by the client at initialization and can be modified later using the [$/setTrace](#setTrace) notification.
+
+```typescript
+export type TraceValue = 'off' | 'message' | 'verbose'
+```
+
 ### Actual Protocol
 
 This section documents the actual language server protocol. It uses the following format:
@@ -1379,7 +1388,7 @@ interface InitializeParams extends WorkDoneProgressParams {
 	/**
 	 * The initial trace setting. If omitted trace is disabled ('off').
 	 */
-	trace?: 'off' | 'messages' | 'verbose';
+	trace?: TraceValue;
 
 	/**
 	 * The workspace folders configured in the client when the server starts.
@@ -1853,6 +1862,50 @@ The server should exit with `success` code 0 if the shutdown request has been re
 _Notification_:
 * method: 'exit'
 * params: void
+
+#### <a href="#logTrace" name="logTrace" class="anchor">LogTrace Notification (:arrow_left:)</a>
+
+A notification to log the trace of the server's execution.
+The amount and content of these notifications depends on the current `trace` configuration.
+If `trace` is `'off'`, the server should not send any `logTrace` notification.
+If `trace` is `'message'`, the server should not add the `'verbose'` field in the `logTraceParams`.
+
+`$/logTrace` should be used for systematic trace reporting. For single debugging messages, the server should send [`window/logMessage`](#window_logMessage) notifications.
+
+
+_Notification_:
+* method: '$/logTrace'
+* params: `logTraceParams` defined as follows:
+
+```typescript
+interface logTraceParams {
+	/**
+	 * The message to be logged.
+	 */
+	message: string;
+	/**
+	 * Additional information that can be computed if the `trace` configuration is set to `'verbose'`
+	 */
+	verbose?: string;
+}
+```
+
+#### <a href="#setTrace" name="setTrace" class="anchor">SetTrace Notification (:arrow_right:)</a>
+
+A notification that should be used by the client to modify the trace setting of the server.
+
+_Notification_:
+* method: '$/setTrace'
+* params: `setTraceParams` defined as follows:
+
+```typescript
+interface setTraceParams {
+	/**
+	 * The new value that should be assigned to the trace setting.
+	 */
+	value: TraceValue;
+}
+```
 
 #### <a href="#window_showMessage" name="window_showMessage" class="anchor">ShowMessage Notification (:arrow_left:)</a>
 

--- a/_specifications/specification-3-16.md
+++ b/_specifications/specification-3-16.md
@@ -18,6 +18,7 @@ All new 3.16 features are tagged with a corresponding since version 3.16 text or
 
 - Call Hierarchy support
 - Semantic Token support
+- Better trace logging support
 
 ## <a href="#baseProtocol" name="baseProtocol" class="anchor"> Base Protocol </a>
 


### PR DESCRIPTION
Hi ! This is a follow-up on #943 

This is just a draft since :
- [x] I'd like to add a sentence about the difference between logTrace and logMessage
- [x] Reference implementation
- [x] I do now know if `logTrace` should be a "general" notification or under the `window` scope
- [x] There should probably be a client capability added for retro-compatibility. In the case of ocaml-lsp, I'd like to know, depending on the client, if I continue to send `logMessage` notifications, or if I can send `logTrace` notifications instead and they will be supported.