### PR TITLE
Use sticky table headers

### DIFF
--- a/css/main.scss
+++ b/css/main.scss
@@ -54,7 +54,8 @@ table.table-responsive.table-bordered {
 			position: -moz-sticky;
 			position: -ms-sticky;
 			position: -o-sticky;
-			top: 55px;
+			top: 3rem; // 2.5rem for the header's height + padding,
+			           // +.5rem for the tr's own padding 
 			background: #fff;
 			outline: 1px solid #e9ecef;
 		}

--- a/css/main.scss
+++ b/css/main.scss
@@ -44,6 +44,23 @@ h2 {
 	margin-bottom: 20px;
 }
 
+table.table-responsive.table-bordered {
+	display: table;
+	& thead > tr {
+		border: none;
+		& > th {
+			position: sticky;
+			position: -webkit-sticky;
+			position: -moz-sticky;
+			position: -ms-sticky;
+			position: -o-sticky;
+			top: 55px;
+			background: #fff;
+			outline: 1px solid #e9ecef;
+		}
+	}
+}
+
 .toc {
 	font-size: 85%
 }


### PR DESCRIPTION
Closes #985. I'm pleased to note that sticky table headers are useful in the specification and SDKs page as well. 

Notes on the implementation: the `table.table-responsive { display: block }` from bootstrap prevented sticky table headers from sticking.  I've checked around and I can't notice any adverse effects from moving back to displaying tables as tables, but I'd recommend reviewers check for unexpected side-effects as well. 