### PR TITLE
ResponseMessage.result can be an array type

### DIFF
--- a/_specifications/specification-3-15.md
+++ b/_specifications/specification-3-15.md
@@ -110,7 +110,7 @@ interface ResponseMessage extends Message {
 	 * The result of a request. This member is REQUIRED on success.
 	 * This member MUST NOT exist if there was an error invoking the method.
 	 */
-	result?: string | number | boolean | object | null;
+	result?: string | number | boolean | array | object | null;
 
 	/**
 	 * The error object in case a request fails.


### PR DESCRIPTION
Certain responses state that they can return arrays (Document Color Request, for example).