### PR TITLE
Document de-facto usage of lowercased driver letters

### DIFF
--- a/_specifications/specification-3-16.md
+++ b/_specifications/specification-3-16.md
@@ -249,6 +249,8 @@ scheme     authority       path        query   fragment
 
 We also maintain a node module to parse a string into `scheme`, `authority`, `path`, `query`, and `fragment` URI components. The GitHub repository is [https://github.com/Microsoft/vscode-uri](https://github.com/Microsoft/vscode-uri) the npm module is [https://www.npmjs.com/package/vscode-uri](https://www.npmjs.com/package/vscode-uri).
 
+On case-insensitive file systems, two textually different URIs might represent the same file.
+
 Many of the interfaces contain fields that correspond to the URI of a document. For clarity, the type of such a field is declared as a `DocumentUri`. Over the wire, it will still be transferred as a string, but this guarantees that the contents of that string can be parsed as a valid URI.
 
 ```typescript


### PR DESCRIPTION
Rust canonicalizes drive letters to the upper case, and that caused a hard-to-debug bug. In the ideal world, both servers and clients would do the actual canonicalization themselves, but I think it's a good idea to document status quo. 