### PR TITLE
Remove now non-existent solidity language server

### DIFF
--- a/_implementors/servers.md
+++ b/_implementors/servers.md
@@ -113,7 +113,6 @@ index: 1
 | T-SQL | MS | [VS Code SQL extension](https://github.com/Microsoft/vscode-mssql/tree/dev/src/languageservice ) | TypeScript, Binary |
 | Scala | [Iulian Dragos](https://github.com/dragos) | [dragos-vscode-scala](https://github.com/dragos/dragos-vscode-scala) | Scala |
 | Scala | [Scalameta](https://github.com/scalameta) | [Metals](https://github.com/scalameta/metals) | Scala |
-| Solidity | Kodebox | [Solidity language server](https://github.com/CodeChain-io/solidity-language-server) | TypeScript |
 | SPARQL | [Stardog Union](https://github.com/stardog-union) | [SPARQL Language Server](https://github.com/stardog-union/stardog-language-servers/tree/master/packages/sparql-language-server) | TypeScript |
 | Svelte | [UnwrittenFun](https://github.com/UnwrittenFun) | [svelte-language-server](https://github.com/UnwrittenFun/svelte-language-server) | TypeScript |
 | Swift | [Apple](https://github.com/apple) | [SourceKit-LSP](https://github.com/apple/sourcekit-lsp) | Swift |


### PR DESCRIPTION
The language server at https://github.com/CodeChain-io/solidity-language-server
does not exist any more.