### PR TITLE
Add window/{did,will}{Create,Rename,Delete}Files

### DIFF
--- a/_specifications/specification-3-16.md
+++ b/_specifications/specification-3-16.md
@@ -3222,7 +3222,7 @@ _Client Capability_:
 * property name (optional): `window.fileOperations.willCreate`
 * property type: `boolean`
 
-The capability indicates that the client supports `window/willCreateFiles` requests.
+The capability indicates that the client supports sending `window/willCreateFiles` requests.
 
 _Server Capability_:
 * property name (optional): `window.fileOperations.willCreate`
@@ -3244,7 +3244,7 @@ interface FileOperationRegistrationOptions {
 }
 ```
 
-The capability indicates that the server is interested in `window/willCreateFiles` requests.
+The capability indicates that the server is interested in receiving `window/willCreateFiles` requests.
 
 _Registration Options_: none
 
@@ -3285,13 +3285,13 @@ _Client Capability_:
 * property name (optional): `window.fileOperations.didCreate`
 * property type: `boolean`
 
-The capability indicates that the client supports `window/didCreateFiles` notifications.
+The capability indicates that the client supports sending `window/didCreateFiles` notifications.
 
 _Server Capability_:
 * property name (optional): `window.fileOperations.didCreate`
 * property type: `FileOperationRegistrationOptions`
 
-The capability indicates that the server is interested in CreateFiles` notifications.
+The capability indicates that the server is interested in receiving `window/didCreateFiles` notifications.
 
 _Notification_:
 * method: 'window/didCreateFiles'
@@ -3305,13 +3305,13 @@ _Client Capability_:
 * property name (optional): `window.fileOperations.willRename`
 * property type: `boolean`
 
-The capability indicates that the client supports `window/willRenameFiles` requests.
+The capability indicates that the client supports sending `window/willRenameFiles` requests.
 
 _Server Capability_:
 * property name (optional): `window.fileOperations.willRename`
 * property type: `FileOperationRegistrationOptions`
 
-The capability indicates that the server is interested in `window/willRenameFiles` requests.
+The capability indicates that the server is interested in receiving `window/willRenameFiles` requests.
 
 _Registration Options_: none
 
@@ -3357,13 +3357,13 @@ _Client Capability_:
 * property name (optional): `window.fileOperations.didRename`
 * property type: `boolean`
 
-The capability indicates that the client supports `window/didRenameFiles` notifications.
+The capability indicates that the client supports sending `window/didRenameFiles` notifications.
 
 _Server Capability_:
 * property name (optional): `window.fileOperations.didRename`
 * property type: `FileOperationRegistrationOptions`
 
-The capability indicates that the server is interested in `window/didRenameFiles` notifications.
+The capability indicates that the server is interested in receiving `window/didRenameFiles` notifications.
 
 _Notification_:
 * method: 'window/didRenameFiles'
@@ -3377,13 +3377,13 @@ _Client Capability_:
 * property name (optional): `window.fileOperations.willDelete`
 * property type: `boolean`
 
-The capability indicates that the client supports `window/willDeleteFiles` requests.
+The capability indicates that the client supports sending `window/willDeleteFiles` requests.
 
 _Server Capability_:
 * property name (optional): `window.fileOperations.willDelete`
 * property type: `FileOperationRegistrationOptions`
 
-The capability indicates that the server is interested in `window/willDeleteFiles` requests.
+The capability indicates that the server is interested in receiving `window/willDeleteFiles` requests.
 
 _Registration Options_: none
 
@@ -3424,13 +3424,13 @@ _Client Capability_:
 * property name (optional): `window.fileOperations.didDelete`
 * property type: `boolean`
 
-The capability indicates that the client supports `window/didDeleteFiles` notifications.
+The capability indicates that the client supports sending `window/didDeleteFiles` notifications.
 
 _Server Capability_:
 * property name (optional): `window.fileOperations.didDelete`
 * property type: `FileOperationRegistrationOptions`
 
-The capability indicates that the server is interested in `window/didDeleteFiles` notifications.
+The capability indicates that the server is interested in receiving `window/didDeleteFiles` notifications.
 
 _Notification_:
 * method: 'window/didDeleteFiles'

--- a/_specifications/specification-3-16.md
+++ b/_specifications/specification-3-16.md
@@ -7252,9 +7252,9 @@ Language servers usually run in a separate process and client communicate with t
 * Add support for code action resolve request.
 * Add support for diagnostic `data` property.
 * Add support for signature information `activeParameter` property.
-* Add support for `workspace/onDidCreateFiles`, `workspace/onWillCreateFiles`
-* Add support for `workspace/onDidRenameFiles`, `workspace/onWillRenameFiles`
-* Add support for `workspace/onDidDeleteFiles`, `workspace/onWillDeleteFiles`
+* Add support for `workspace/didCreateFiles` notifications and `workspace/willCreateFiles` requests.
+* Add support for `workspace/didRenameFiles` notifications and `workspace/willRenameFiles` requests.
+* Add support for `workspace/didDeleteFiles` notifications and `workspace/willDeleteFiles` requests.
 
 #### <a href="#version_3_15_0" name="version_3_15_0" class="anchor">3.15.0 (01/14/2020)</a>
 

--- a/_specifications/specification-3-16.md
+++ b/_specifications/specification-3-16.md
@@ -3375,8 +3375,22 @@ interface FileOperationPattern {
 	 *
 	 * Matches both if undefined.
 	 */
-	matches?: 'file' | 'folder';
+	matches?: FileOperationPatternKind;
 }
+
+export namespace FileOperationPatternKind {
+	/**
+	 * The pattern matches a file only.
+	 */
+	export const file: 'file' = 'file';
+
+	/**
+	 * The pattern matches a folder only.
+	 */
+	export const folder: 'folder' = 'folder';
+}
+
+export type FileOperationPatternKind = 'file' | 'folder';
 ```
 
 The capability indicates that the server is interested in receiving `workspace/willCreateFiles` requests.

--- a/_specifications/specification-3-16.md
+++ b/_specifications/specification-3-16.md
@@ -2879,13 +2879,13 @@ export interface ApplyWorkspaceEditResponse {
 The will rename files notification is sent from the client to the server before files are actually renamed.
 
 _Client Capability_:
-* property name (optional): `workspace.renameFiles.willRenameFiles`
+* property name (optional): `workspace.files.willRename`
 * property type: `boolean`
 
 The capability indicates that the client supports `workspace/willRenameFiles` notifications.
 
 _Server Capability_:
-* property name (optional): `workspace.renameFiles.willRenameFiles`
+* property name (optional): `workspace.files.willRename`
 * property type: `bool`
 
 The capability indicates that the server is interested in `workspace/willRenameFiles` notifications.
@@ -2927,13 +2927,13 @@ export namespace FileRename {
 The will rename files wait until request is sent from the client to the server before files are actually renamed. The request can return a WorkspaceEdit which will be applied to workspace before the files are renamed. Please note that clients might drop results if computing the edit took too long or if a server constantly fails on this request. This is done to keep renames fast and reliable.
 
 _Client Capability_:
-* property name (optional): `workspace.renameFiles.willRenameFilesWaitUntil`
+* property name (optional): `workspace.files.willRenameWaitUntil`
 * property type: `boolean`
 
 The capability indicates that the client supports `workspace/willRenameFilesWaitUntil` requests.
 
 _Server Capability_:
-* property name (optional): `workspace.renameFiles.willRenameFilesWaitUntil`
+* property name (optional): `workspace.files.willRenameWaitUntil`
 * property type: `boolean`
 
 The capability indicates that the server is interested in `workspace/willRenameFilesWaitUntil` requests.
@@ -2953,13 +2953,13 @@ _Response_:
 The did rename files notification is sent from the client to the server when files were renamed in the client.
 
 _Client Capability_:
-* property name (optional): `workspace.renameFiles.didRenameFiles`
+* property name (optional): `workspace.files.didRename`
 * property type: `boolean`
 
 The capability indicates that the client supports `workspace/didRenameFiles` notifications.
 
 _Server Capability_:
-* property name (optional): `workspace.renameFiles.didRenameFiles`
+* property name (optional): `workspace.files.didRename`
 * property type: `boolean`
 
 The capability indicates that the server is interested in `workspace/didRenameFiles` notifications.

--- a/_specifications/specification-3-16.md
+++ b/_specifications/specification-3-16.md
@@ -1691,25 +1691,25 @@ interface ClientCapabilities {
 		workspaceFolders?: boolean;
 
 		/**
-		* The client has support for rename requests/notifications.
+		* The client has support for file requests/notifications.
 		*
 		* Since 3.16.0
 		*/
-		renameFiles?: {
+		files?: {
 			/**
-			 * The client has support for didRenameFiles notifications.
+			 * The client has support for sending didRename file notifications.
 			 */
-			didRenameFiles?: boolean;
+			didRename?: boolean;
 
 			/**
-			 * The client has support for willRenameFiles notifications.
+			 * The client has support for willRename file notifications.
 			 */
-			willRenameFiles?: boolean;
+			willRename?: boolean;
 
 			/**
-			 * The client has support for willRenameFilesWaitUntil requests.
+			 * The client has support for willRename files requests.
 			 */
-			willRenameFilesWaitUntil?: boolean;
+			willRenameWaitUntil?: boolean;
 		}
 
 		/**
@@ -1987,25 +1987,25 @@ interface ServerCapabilities {
 	}
 
 	/**
-		* The server is interested in rename notifications/requests.
-		*
-		* @since 3.16.0
-		*/
-	renameFiles?: {
+	* The server is interested in rename notifications/requests.
+	*
+	* @since 3.16.0
+	*/
+	files?: {
 		/**
 		* The server is interested in didRenameFiles notifications.
 		*/
-		didRenameFiles?: boolean;
+		didRename?: boolean;
 
 		/**
 		* The server is interested in willRenameFiles notifications.
 		*/
-		willRenameFiles?: boolean;
+		willRename?: boolean;
 
 		/**
 		* The server is interested in willRenameFilesWaitUntil requests.
 		*/
-		willRenameFilesWaitUntil?: boolean;
+		willRenameWaitUntil?: boolean;
 	}
 
 	/**

--- a/_specifications/specification-3-16.md
+++ b/_specifications/specification-3-16.md
@@ -1825,48 +1825,6 @@ interface ClientCapabilities {
 		workspaceFolders?: boolean;
 
 		/**
-		* The client has support for file requests/notifications.
-		*
-		* Since 3.16.0
-		*/
-		files?: {
-			/**
-			 * Whether the client supports dynamic registration for file requests/notifications.
-			 */
-			dynamicRegistration?: boolean;
-
-			/**
-			 * The client has support for sending didCreateFiles notifications.
-			 */
-			didCreate?: boolean;
-
-			/**
-			 * The client has support for willCreateFiles requests.
-			 */
-			willCreate?: boolean;
-
-			/**
-			 * The client has support for sending didRenameFiles notifications.
-			 */
-			didRename?: boolean;
-
-			/**
-			 * The client has support for willRenameFiles requests.
-			 */
-			willRename?: boolean;
-
-			/**
-			 * The client has support for sending didDeleteFiles notifications.
-			 */
-			didDelete?: boolean;
-
-			/**
-			 * The client has support for willDeleteFiles requests.
-			 */
-			willDelete?: boolean;
-		}
-
-		/**
 		 * The client supports `workspace/configuration` requests.
 		 *
 		 * @since 3.6.0
@@ -1921,6 +1879,48 @@ interface ClientCapabilities {
 		 * @since 3.16.0 - proposed state
 		 */
 		showDocument?: ShowDocumentClientCapabilities;
+
+		/**
+		* The client has support for file requests/notifications.
+		*
+		* Since 3.16.0
+		*/
+		fileOperations?: {
+			/**
+			 * Whether the client supports dynamic registration for file requests/notifications.
+			 */
+			dynamicRegistration?: boolean;
+
+			/**
+			 * The client has support for sending didCreateFiles notifications.
+			 */
+			didCreate?: boolean;
+
+			/**
+			 * The client has support for willCreateFiles requests.
+			 */
+			willCreate?: boolean;
+
+			/**
+			 * The client has support for sending didRenameFiles notifications.
+			 */
+			didRename?: boolean;
+
+			/**
+			 * The client has support for willRenameFiles requests.
+			 */
+			willRename?: boolean;
+
+			/**
+			 * The client has support for sending didDeleteFiles notifications.
+			 */
+			didDelete?: boolean;
+
+			/**
+			 * The client has support for willDeleteFiles requests.
+			 */
+			willDelete?: boolean;
+		}
 	}
 
 	/**
@@ -2190,40 +2190,45 @@ interface ServerCapabilities {
 	}
 
 	/**
-	* The server is interested in file notifications/requests.
-	*
-	* @since 3.16.0
-	*/
-	files?: {
+	 * Window specific server capabilities
+	 */
+	window?: {
 		/**
-		* The server is interested in didCreateFiles notifications.
+		* The server is interested in file notifications/requests.
+		*
+		* @since 3.16.0
 		*/
-		didCreate?: FileOperationRegistrationOptions;
+		fileOperations?: {
+			/**
+			* The server is interested in didCreateFiles notifications.
+			*/
+			didCreate?: FileOperationRegistrationOptions;
 
-		/**
-		* The server is interested in willCreateFiles requests.
-		*/
-		willCreate?: FileOperationRegistrationOptions;
+			/**
+			* The server is interested in willCreateFiles requests.
+			*/
+			willCreate?: FileOperationRegistrationOptions;
 
-		/**
-		* The server is interested in didRenameFiles notifications.
-		*/
-		didRename?: FileOperationRegistrationOptions;
+			/**
+			* The server is interested in didRenameFiles notifications.
+			*/
+			didRename?: FileOperationRegistrationOptions;
 
-		/**
-		* The server is interested in willRenameFiles requests.
-		*/
-		willRename?: FileOperationRegistrationOptions;
+			/**
+			* The server is interested in willRenameFiles requests.
+			*/
+			willRename?: FileOperationRegistrationOptions;
 
-		/**
-		* The server is interested in didDeleteFiles file notifications.
-		*/
-		didDelete?: FileOperationRegistrationOptions;
+			/**
+			* The server is interested in didDeleteFiles file notifications.
+			*/
+			didDelete?: FileOperationRegistrationOptions;
 
-		/**
-		* The server is interested in willDeleteFiles file requests.
-		*/
-		willDelete?: FileOperationRegistrationOptions;
+			/**
+			* The server is interested in willDeleteFiles file requests.
+			*/
+			willDelete?: FileOperationRegistrationOptions;
+		}
 	}
 
 	/**

--- a/_specifications/specification-3-16.md
+++ b/_specifications/specification-3-16.md
@@ -7327,7 +7327,9 @@ Language servers usually run in a separate process and client communicate with t
 * Add support for code action resolve request.
 * Add support for diagnostic `data` property.
 * Add support for signature information `activeParameter` property.
+* Add support for `workspace/onWillCreateFiles`, `workspace/onWillCreateFilesWaitUntil` and `workspace/onDidCreateFiles`
 * Add support for `workspace/onWillRenameFiles`, `workspace/onWillRenameFilesWaitUntil` and `workspace/onDidRenameFiles`
+* Add support for `workspace/onWillDeleteFiles`, `workspace/onWillDeleteFilesWaitUntil` and `workspace/onDidDeleteFiles`
 
 #### <a href="#version_3_15_0" name="version_3_15_0" class="anchor">3.15.0 (01/14/2020)</a>
 

--- a/_specifications/specification-3-16.md
+++ b/_specifications/specification-3-16.md
@@ -2007,7 +2007,7 @@ interface ServerCapabilities {
 	}
 
 	/**
-	* The server is interested in rename notifications/requests.
+	* The server is interested in file notifications/requests.
 	*
 	* @since 3.16.0
 	*/
@@ -2914,7 +2914,7 @@ export interface ApplyWorkspaceEditResponse {
 The will create files request is sent from the client to the server before files are actually created. The request can return a WorkspaceEdit which will be applied to workspace before the files are created. Please note that clients might drop results if computing the edit took too long or if a server constantly fails on this request. This is done to keep creates fast and reliable.
 
 _Client Capability_:
-* property name (optional): `workspace.files.willCreateWait`
+* property name (optional): `workspace.files.willCreate`
 * property type: `boolean`
 
 The capability indicates that the client supports `workspace/willCreateFiles` requests.
@@ -2984,7 +2984,7 @@ The capability indicates that the client supports `workspace/didCreateFiles` not
 
 _Server Capability_:
 * property name (optional): `workspace.files.didCreate`
-* property type: `boolean`
+* property type: `FileOperationRegistrationOptions`
 
 The capability indicates that the server is interested in `workspace/didCreateFiles` notifications.
 
@@ -3004,7 +3004,7 @@ The capability indicates that the client supports `workspace/willRenameFiles` re
 
 _Server Capability_:
 * property name (optional): `workspace.files.willRename`
-* property type: `boolean`
+* property type: `FileOperationRegistrationOptions`
 
 The capability indicates that the server is interested in `workspace/willRenameFiles` requests.
 
@@ -3056,7 +3056,7 @@ The capability indicates that the client supports `workspace/didRenameFiles` not
 
 _Server Capability_:
 * property name (optional): `workspace.files.didRename`
-* property type: `boolean`
+* property type: `FileOperationRegistrationOptions`
 
 The capability indicates that the server is interested in `workspace/didRenameFiles` notifications.
 
@@ -3076,7 +3076,7 @@ The capability indicates that the client supports `workspace/willDeleteFiles` re
 
 _Server Capability_:
 * property name (optional): `workspace.files.willDelete`
-* property type: `boolean`
+* property type: `FileOperationRegistrationOptions`
 
 The capability indicates that the server is interested in `workspace/willDeleteFiles` requests.
 
@@ -3123,7 +3123,7 @@ The capability indicates that the client supports `workspace/didDeleteFiles` not
 
 _Server Capability_:
 * property name (optional): `workspace.files.didDelete`
-* property type: `boolean`
+* property type: `FileOperationRegistrationOptions`
 
 The capability indicates that the server is interested in `workspace/didDeleteFiles` notifications.
 

--- a/_specifications/specification-3-16.md
+++ b/_specifications/specification-3-16.md
@@ -2010,32 +2010,32 @@ interface ServerCapabilities {
 		/**
 		* The server is interested in didCreateFiles notifications.
 		*/
-		didCreate?: boolean;
+		didCreate?: FileOperationRegistrationOptions;
 
 		/**
 		* The server is interested in willCreateFiles requests.
 		*/
-		willCreate?: boolean;
+		willCreate?: FileOperationRegistrationOptions;
 
 		/**
 		* The server is interested in didRenameFiles notifications.
 		*/
-		didRename?: boolean;
+		didRename?: FileOperationRegistrationOptions;
 
 		/**
 		* The server is interested in willRenameFiles requests.
 		*/
-		willRename?: boolean;
+		willRename?: FileOperationRegistrationOptions;
 
 		/**
 		* The server is interested in didDeleteFiles file notifications.
 		*/
-		didDelete?: boolean;
+		didDelete?: FileOperationRegistrationOptions;
 
 		/**
 		* The server is interested in willDeleteFiles file requests.
 		*/
-		willDelete?: boolean;
+		willDelete?: FileOperationRegistrationOptions;
 	}
 
 	/**
@@ -2916,7 +2916,23 @@ The capability indicates that the client supports `workspace/willCreateFiles` re
 
 _Server Capability_:
 * property name (optional): `workspace.files.willCreate`
-* property type: `boolean`
+* property type: `FileOperationRegistrationOptions` where `FileOperationRegistrationOptions` is defined as follows:
+
+```typescript
+interface FileOperationRegistrationOptions {
+	/**
+	 * The glob pattern to match. Glob patterns can have the following syntax:
+	 * - `*` to match one or more characters in a path segment
+	 * - `?` to match on one character in a path segment
+	 * - `**` to match any number of path segments, including none
+	 * - `{}` to group conditions (e.g. `**​/*.{ts,js}` matches all TypeScript and JavaScript files)
+	 * - `[]` to declare a range of characters to match in a path segment (e.g., `example.[0-9]` to match on `example.0`, `example.1`, …)
+	 * - `[!...]` to negate a range of characters to match in a path segment (e.g., `example.[!0-9]` to match on `example.a`, `example.b`, but not `example.0`)
+	 * - `/` suffix to match only folders (e.g. `**{/,*.dart}` matches all Dart files and all folders)
+	 */
+	globPattern: string;
+}
+```
 
 The capability indicates that the server is interested in `workspace/willCreateFiles` requests.
 

--- a/_specifications/specification-3-16.md
+++ b/_specifications/specification-3-16.md
@@ -1967,39 +1967,6 @@ interface ClientCapabilities {
 		 * @since 3.16.0 - proposed state
 		 */
 		codeLens?: CodeLensWorkspaceClientCapabilities;
-	};
-
-	/**
-	 * Text document specific client capabilities.
-	 */
-	textDocument?: TextDocumentClientCapabilities;
-
-	/**
-	 * Window specific client capabilities.
-	 */
-	window?: {
-		/**
-		 * Whether client supports handling progress notifications. If set
-		 * servers are allowed to report in `workDoneProgress` property in the
-		 * request specific server capabilities.
-		 *
-		 * @since 3.15.0
-		 */
-		workDoneProgress?: boolean;
-
-		/**
-		 * Capabilities specific to the showMessage request
-		 *
-		 * @since 3.16.0 - proposed state
-		 */
-		showMessage?: ShowMessageRequestClientCapabilities;
-
-		/**
-		 * Client capabilities for the show document request.
-		 *
-		 * @since 3.16.0 - proposed state
-		 */
-		showDocument?: ShowDocumentClientCapabilities;
 
 		/**
 		* The client has support for file requests/notifications.
@@ -2042,6 +2009,39 @@ interface ClientCapabilities {
 			 */
 			willDelete?: boolean;
 		}
+	};
+
+	/**
+	 * Text document specific client capabilities.
+	 */
+	textDocument?: TextDocumentClientCapabilities;
+
+	/**
+	 * Window specific client capabilities.
+	 */
+	window?: {
+		/**
+		 * Whether client supports handling progress notifications. If set
+		 * servers are allowed to report in `workDoneProgress` property in the
+		 * request specific server capabilities.
+		 *
+		 * @since 3.15.0
+		 */
+		workDoneProgress?: boolean;
+
+		/**
+		 * Capabilities specific to the showMessage request
+		 *
+		 * @since 3.16.0 - proposed state
+		 */
+		showMessage?: ShowMessageRequestClientCapabilities;
+
+		/**
+		 * Client capabilities for the show document request.
+		 *
+		 * @since 3.16.0 - proposed state
+		 */
+		showDocument?: ShowDocumentClientCapabilities;
 	}
 
 	/**
@@ -2317,12 +2317,7 @@ interface ServerCapabilities {
 		 * @since 3.6.0
 		 */
 		workspaceFolders?: WorkspaceFoldersServerCapabilities;
-	}
 
-	/**
-	 * Window specific server capabilities
-	 */
-	window?: {
 		/**
 		* The server is interested in file notifications/requests.
 		*
@@ -3344,18 +3339,18 @@ export interface ApplyWorkspaceEditResponse {
 ```
 * error: code and message set in case an exception happens during the request.
 
-#### <a href="#window_willCreateFiles" name="window_willCreateFiles" class="anchor">WillCreateFiles Request (:leftwards_arrow_with_hook:)</a>
+#### <a href="#workspace_willCreateFiles" name="workspace_willCreateFiles" class="anchor">WillCreateFiles Request (:leftwards_arrow_with_hook:)</a>
 
 The will create files request is sent from the client to the server before files are actually created. The request can return a WorkspaceEdit which will be applied to workspace before the files are created. Please note that clients might drop results if computing the edit took too long or if a server constantly fails on this request. This is done to keep creates fast and reliable.
 
 _Client Capability_:
-* property name (optional): `window.fileOperations.willCreate`
+* property name (optional): `workspace.fileOperations.willCreate`
 * property type: `boolean`
 
-The capability indicates that the client supports sending `window/willCreateFiles` requests.
+The capability indicates that the client supports sending `workspace/willCreateFiles` requests.
 
 _Server Capability_:
-* property name (optional): `window.fileOperations.willCreate`
+* property name (optional): `workspace.fileOperations.willCreate`
 * property type: `FileOperationRegistrationOptions` where `FileOperationRegistrationOptions` is defined as follows:
 
 ```typescript
@@ -3374,12 +3369,12 @@ interface FileOperationRegistrationOptions {
 }
 ```
 
-The capability indicates that the server is interested in receiving `window/willCreateFiles` requests.
+The capability indicates that the server is interested in receiving `workspace/willCreateFiles` requests.
 
 _Registration Options_: none
 
 _Request_:
-* method: 'window/willCreateFiles'
+* method: 'workspace/willCreateFiles'
 * params: `CreateFilesParams` defined as follows:
 
 ```typescript
@@ -3407,46 +3402,46 @@ _Response_:
 * result:`WorkspaceEdit` \| `null`
 * error: code and message set in case an exception happens during the `willCreateFiles` request.
 
-#### <a href="#window_didCreateFiles" name="window_didCreateFiles" class="anchor">DidCreateFiles Notification (:arrow_right:)</a>
+#### <a href="#workspace_didCreateFiles" name="workspace_didCreateFiles" class="anchor">DidCreateFiles Notification (:arrow_right:)</a>
 
 The did create files notification is sent from the client to the server when files were created in the client.
 
 _Client Capability_:
-* property name (optional): `window.fileOperations.didCreate`
+* property name (optional): `workspace.fileOperations.didCreate`
 * property type: `boolean`
 
-The capability indicates that the client supports sending `window/didCreateFiles` notifications.
+The capability indicates that the client supports sending `workspace/didCreateFiles` notifications.
 
 _Server Capability_:
-* property name (optional): `window.fileOperations.didCreate`
+* property name (optional): `workspace.fileOperations.didCreate`
 * property type: `FileOperationRegistrationOptions`
 
-The capability indicates that the server is interested in receiving `window/didCreateFiles` notifications.
+The capability indicates that the server is interested in receiving `workspace/didCreateFiles` notifications.
 
 _Notification_:
-* method: 'window/didCreateFiles'
+* method: 'workspace/didCreateFiles'
 * params: `CreateFilesParams`
 
-#### <a href="#window_willRenameFiles" name="window_willRenameFiles" class="anchor">WillRenameFiles Request (:leftwards_arrow_with_hook:)</a>
+#### <a href="#workspace_willRenameFiles" name="workspace_willRenameFiles" class="anchor">WillRenameFiles Request (:leftwards_arrow_with_hook:)</a>
 
 The will rename files request is sent from the client to the server before files are actually renamed. The request can return a WorkspaceEdit which will be applied to workspace before the files are renamed. Please note that clients might drop results if computing the edit took too long or if a server constantly fails on this request. This is done to keep renames fast and reliable.
 
 _Client Capability_:
-* property name (optional): `window.fileOperations.willRename`
+* property name (optional): `workspace.fileOperations.willRename`
 * property type: `boolean`
 
-The capability indicates that the client supports sending `window/willRenameFiles` requests.
+The capability indicates that the client supports sending `workspace/willRenameFiles` requests.
 
 _Server Capability_:
-* property name (optional): `window.fileOperations.willRename`
+* property name (optional): `workspace.fileOperations.willRename`
 * property type: `FileOperationRegistrationOptions`
 
-The capability indicates that the server is interested in receiving `window/willRenameFiles` requests.
+The capability indicates that the server is interested in receiving `workspace/willRenameFiles` requests.
 
 _Registration Options_: none
 
 _Request_:
-* method: 'window/willRenameFiles'
+* method: 'workspace/willRenameFiles'
 * params: `RenameFilesParams` defined as follows:
 
 ```typescript
@@ -3479,46 +3474,46 @@ _Response_:
 * result:`WorkspaceEdit` \| `null`
 * error: code and message set in case an exception happens during the `willRenameFiles` request.
 
-#### <a href="#window_didRenameFiles" name="window_didRenameFiles" class="anchor">DidRenameFiles Notification (:arrow_right:)</a>
+#### <a href="#workspace_didRenameFiles" name="workspace_didRenameFiles" class="anchor">DidRenameFiles Notification (:arrow_right:)</a>
 
 The did rename files notification is sent from the client to the server when files were renamed in the client.
 
 _Client Capability_:
-* property name (optional): `window.fileOperations.didRename`
+* property name (optional): `workspace.fileOperations.didRename`
 * property type: `boolean`
 
-The capability indicates that the client supports sending `window/didRenameFiles` notifications.
+The capability indicates that the client supports sending `workspace/didRenameFiles` notifications.
 
 _Server Capability_:
-* property name (optional): `window.fileOperations.didRename`
+* property name (optional): `workspace.fileOperations.didRename`
 * property type: `FileOperationRegistrationOptions`
 
-The capability indicates that the server is interested in receiving `window/didRenameFiles` notifications.
+The capability indicates that the server is interested in receiving `workspace/didRenameFiles` notifications.
 
 _Notification_:
-* method: 'window/didRenameFiles'
+* method: 'workspace/didRenameFiles'
 * params: `RenameFilesParams`
 
-#### <a href="#window_willDeleteFiles" name="window_willDeleteFiles" class="anchor">WillDeleteFiles Request (:leftwards_arrow_with_hook:)</a>
+#### <a href="#workspace_willDeleteFiles" name="workspace_willDeleteFiles" class="anchor">WillDeleteFiles Request (:leftwards_arrow_with_hook:)</a>
 
 The will delete files request is sent from the client to the server before files are actually deleted. The request can return a WorkspaceEdit which will be applied to workspace before the files are deleted. Please note that clients might drop results if computing the edit took too long or if a server constantly fails on this request. This is done to keep deletes fast and reliable.
 
 _Client Capability_:
-* property name (optional): `window.fileOperations.willDelete`
+* property name (optional): `workspace.fileOperations.willDelete`
 * property type: `boolean`
 
-The capability indicates that the client supports sending `window/willDeleteFiles` requests.
+The capability indicates that the client supports sending `workspace/willDeleteFiles` requests.
 
 _Server Capability_:
-* property name (optional): `window.fileOperations.willDelete`
+* property name (optional): `workspace.fileOperations.willDelete`
 * property type: `FileOperationRegistrationOptions`
 
-The capability indicates that the server is interested in receiving `window/willDeleteFiles` requests.
+The capability indicates that the server is interested in receiving `workspace/willDeleteFiles` requests.
 
 _Registration Options_: none
 
 _Request_:
-* method: 'window/willDeleteFiles'
+* method: 'workspace/willDeleteFiles'
 * params: `DeleteFilesParams` defined as follows:
 
 ```typescript
@@ -3546,24 +3541,24 @@ _Response_:
 * result:`WorkspaceEdit` \| `null`
 * error: code and message set in case an exception happens during the `willDeleteFiles` request.
 
-#### <a href="#window_didDeleteFiles" name="window_didDeleteFiles" class="anchor">DidDeleteFiles Notification (:arrow_right:)</a>
+#### <a href="#workspace_didDeleteFiles" name="workspace_didDeleteFiles" class="anchor">DidDeleteFiles Notification (:arrow_right:)</a>
 
 The did delete files notification is sent from the client to the server when files were deleted in the client.
 
 _Client Capability_:
-* property name (optional): `window.fileOperations.didDelete`
+* property name (optional): `workspace.fileOperations.didDelete`
 * property type: `boolean`
 
-The capability indicates that the client supports sending `window/didDeleteFiles` notifications.
+The capability indicates that the client supports sending `workspace/didDeleteFiles` notifications.
 
 _Server Capability_:
-* property name (optional): `window.fileOperations.didDelete`
+* property name (optional): `workspace.fileOperations.didDelete`
 * property type: `FileOperationRegistrationOptions`
 
-The capability indicates that the server is interested in receiving `window/didDeleteFiles` notifications.
+The capability indicates that the server is interested in receiving `workspace/didDeleteFiles` notifications.
 
 _Notification_:
-* method: 'window/didDeleteFiles'
+* method: 'workspace/didDeleteFiles'
 * params: `DeleteFilesParams`
 
 #### <a href="#textDocument_synchronization" name="textDocument_synchronization" class="anchor">Text Document Synchronization</a>
@@ -7977,9 +7972,9 @@ Servers usually support different communication channels (e.g. stdio, pipes, ...
 * Add support for code action resolve request.
 * Add support for diagnostic `data` property.
 * Add support for signature information `activeParameter` property.
-* Add support for `window/didCreateFiles` notifications and `window/willCreateFiles` requests.
-* Add support for `window/didRenameFiles` notifications and `window/willRenameFiles` requests.
-* Add support for `window/didDeleteFiles` notifications and `window/willDeleteFiles` requests.
+* Add support for `workspace/didCreateFiles` notifications and `workspace/willCreateFiles` requests.
+* Add support for `workspace/didRenameFiles` notifications and `workspace/willRenameFiles` requests.
+* Add support for `workspace/didDeleteFiles` notifications and `workspace/willDeleteFiles` requests.
 * Add client capability to signal whether the client normalizes line endings.
 * Add support to preserve additional attributes on `MessageActionItem`.
 * Add support to provide the clients locale in the initialize call.

--- a/_specifications/specification-3-16.md
+++ b/_specifications/specification-3-16.md
@@ -1691,6 +1691,28 @@ interface ClientCapabilities {
 		workspaceFolders?: boolean;
 
 		/**
+		* The client has support for rename requests/notifications.
+		*
+		* Since 3.16.0
+		*/
+		renameFiles?: {
+			/**
+			 * The client has support for didRenameFiles notifications.
+			 */
+			didRenameFiles?: boolean;
+
+			/**
+			 * The client has support for willRenameFiles notifications.
+			 */
+			willRenameFiles?: boolean;
+
+			/**
+			 * The client has support for willRenameFilesWaitUntil requests.
+			 */
+			willRenameFilesWaitUntil?: boolean;
+		}
+
+		/**
 		 * The client supports `workspace/configuration` requests.
 		 *
 		 * @since 3.6.0
@@ -1962,6 +1984,28 @@ interface ServerCapabilities {
 		 * @since 3.6.0
 		 */
 		workspaceFolders?: WorkspaceFoldersServerCapabilities;
+	}
+
+	/**
+		* The server is interested in rename notifications/requests.
+		*
+		* @since 3.16.0
+		*/
+	renameFiles?: {
+		/**
+		* The server is interested in didRenameFiles notifications.
+		*/
+		didRenameFiles?: boolean;
+
+		/**
+		* The server is interested in willRenameFiles notifications.
+		*/
+		willRenameFiles?: boolean;
+
+		/**
+		* The server is interested in willRenameFilesWaitUntil requests.
+		*/
+		willRenameFilesWaitUntil?: boolean;
 	}
 
 	/**
@@ -2829,6 +2873,100 @@ export interface ApplyWorkspaceEditResponse {
 }
 ```
 * error: code and message set in case an exception happens during the request.
+
+#### <a href="#workspace_willRenameFiles" name="workspace_willRename" class="anchor">WillRenameFiles Notification (:arrow_right:)</a>
+
+The will rename files notification is sent from the client to the server before files are actually renamed.
+
+_Client Capability_:
+* property name (optional): `workspace.renameFiles.willRenameFiles`
+* property type: `boolean`
+
+The capability indicates that the client supports `workspace/willRenameFiles` notifications.
+
+_Server Capability_:
+* property name (optional): `workspace.renameFiles.willRenameFiles`
+* property type: `bool`
+
+The capability indicates that the server is interested in `workspace/willRenameFiles` notifications.
+
+_Registration Options_: none
+
+_Notification_:
+* method: 'workspace/willRenameFiles'
+* params: `RenameFilesParams` defined as follows:
+
+```typescript
+/**
+ * The parameters sent in file rename requests/notifications.
+ */
+export interface RenameFilesParams {
+	/**
+	 * An array of all files/folders renamed in this operation. When a folder is renamed, only
+	 * the folder will be included, and not its children.
+	 */
+	files: FileRename[];
+}
+/**
+ * Represents information on a file/folder rename.
+ */
+export namespace FileRename {
+	/**
+	 * A file:// URI for the original location of the file/folder being renamed.
+	 */
+	oldUri: string;
+	/**
+	 * A file:// URI for the new location of the file/folder being renamed.
+	 */
+	newUri: string;
+}
+```
+
+#### <a href="#workspace_willRenameFilesWaitUntil" name="workspace_willRenameFilesWaitUntil" class="anchor">WillRenameFilesWaitUntil Request (:leftwards_arrow_with_hook:)</a>
+
+The will rename files wait until request is sent from the client to the server before files are actually renamed. The request can return a WorkspaceEdit which will be applied to workspace before the files are renamed. Please note that clients might drop results if computing the edit took too long or if a server constantly fails on this request. This is done to keep renames fast and reliable.
+
+_Client Capability_:
+* property name (optional): `workspace.renameFiles.willRenameFilesWaitUntil`
+* property type: `boolean`
+
+The capability indicates that the client supports `workspace/willRenameFilesWaitUntil` requests.
+
+_Server Capability_:
+* property name (optional): `workspace.renameFiles.willRenameFilesWaitUntil`
+* property type: `boolean`
+
+The capability indicates that the server is interested in `workspace/willRenameFilesWaitUntil` requests.
+
+_Registration Options_: none
+
+_Request_:
+* method: 'workspace/willRenameFilesWaitUntil'
+* params: `RenameFilesParams`
+
+_Response_:
+* result:`WorkspaceEdit` \| `null`
+* error: code and message set in case an exception happens during the `willRenameFilesWaitUntil` request.
+
+#### <a href="#workspace_didRenameFiles" name="workspace_didRenameFiles" class="anchor">DidRenameFiles Notification (:arrow_right:)</a>
+
+The did rename files notification is sent from the client to the server when files were renamed in the client.
+
+_Client Capability_:
+* property name (optional): `workspace.renameFiles.didRenameFiles`
+* property type: `boolean`
+
+The capability indicates that the client supports `workspace/didRenameFiles` notifications.
+
+_Server Capability_:
+* property name (optional): `workspace.renameFiles.didRenameFiles`
+* property type: `boolean`
+
+The capability indicates that the server is interested in `workspace/didRenameFiles` notifications.
+
+_Notification_:
+* method: 'workspace/didRenameFiles'
+* params: `RenameFilesParams`
 
 #### <a href="#textDocument_synchronization" name="textDocument_synchronization" class="anchor">Text Document Synchronization</a>
 
@@ -3903,7 +4041,7 @@ export interface HoverOptions extends WorkDoneProgressOptions {
 
 _Registration Options_: `HoverRegistrationOptions` defined as follows:
 ```typescript
-export interface HoverRegistrationOptions 
+export interface HoverRegistrationOptions
 	extends TextDocumentRegistrationOptions, HoverOptions {
 }
 ```
@@ -4989,7 +5127,7 @@ export interface CodeActionOptions extends WorkDoneProgressOptions {
 	/**
 	 * CodeActionKinds that this server may return.
 	 *
-	 * The list of kinds may be generic, such as `CodeActionKind.Refactor`, 
+	 * The list of kinds may be generic, such as `CodeActionKind.Refactor`,
 	 * or the server may list out every specific kind they provide.
 	 */
 	codeActionKinds?: CodeActionKind[];
@@ -6951,6 +7089,7 @@ Language servers usually run in a separate process and client communicate with t
 * Add support for code action resolve request.
 * Add support for diagnostic `data` property.
 * Add support for signature information `activeParameter` property.
+* Add support for `workspace/onWillRenameFiles`, `workspace/onWillRenameFilesWaitUntil` and `workspace/onDidRenameFiles`
 
 #### <a href="#version_3_15_0" name="version_3_15_0" class="anchor">3.15.0 (01/14/2020)</a>
 

--- a/_specifications/specification-3-16.md
+++ b/_specifications/specification-3-16.md
@@ -1697,6 +1697,11 @@ interface ClientCapabilities {
 		*/
 		files?: {
 			/**
+			 * Whether the client supports dynamic registration for file requests/notifications.
+			 */
+			dynamicRegistration?: boolean;
+
+			/**
 			 * The client has support for sending didCreateFiles notifications.
 			 */
 			didCreate?: boolean;

--- a/_specifications/specification-3-16.md
+++ b/_specifications/specification-3-16.md
@@ -3222,7 +3222,7 @@ _Client Capability_:
 * property name (optional): `window.fileOperations.willCreate`
 * property type: `boolean`
 
-The capability indicates that the client supports `workspace/willCreateFiles` requests.
+The capability indicates that the client supports `window/willCreateFiles` requests.
 
 _Server Capability_:
 * property name (optional): `window.fileOperations.willCreate`

--- a/_specifications/specification-3-16.md
+++ b/_specifications/specification-3-16.md
@@ -3209,18 +3209,18 @@ export interface ApplyWorkspaceEditResponse {
 ```
 * error: code and message set in case an exception happens during the request.
 
-#### <a href="#workspace_willCreateFiles" name="workspace_willCreateFiles" class="anchor">WillCreateFiles Request (:leftwards_arrow_with_hook:)</a>
+#### <a href="#window_willCreateFiles" name="window_willCreateFiles" class="anchor">WillCreateFiles Request (:leftwards_arrow_with_hook:)</a>
 
 The will create files request is sent from the client to the server before files are actually created. The request can return a WorkspaceEdit which will be applied to workspace before the files are created. Please note that clients might drop results if computing the edit took too long or if a server constantly fails on this request. This is done to keep creates fast and reliable.
 
 _Client Capability_:
-* property name (optional): `workspace.files.willCreate`
+* property name (optional): `window.fileOperations.willCreate`
 * property type: `boolean`
 
 The capability indicates that the client supports `workspace/willCreateFiles` requests.
 
 _Server Capability_:
-* property name (optional): `workspace.files.willCreate`
+* property name (optional): `window.fileOperations.willCreate`
 * property type: `FileOperationRegistrationOptions` where `FileOperationRegistrationOptions` is defined as follows:
 
 ```typescript
@@ -3239,17 +3239,17 @@ interface FileOperationRegistrationOptions {
 }
 ```
 
-The capability indicates that the server is interested in `workspace/willCreateFiles` requests.
+The capability indicates that the server is interested in `window/willCreateFiles` requests.
 
 _Registration Options_: none
 
 _Request_:
-* method: 'workspace/willCreateFiles'
+* method: 'window/willCreateFiles'
 * params: `CreateFilesParams` defined as follows:
 
 ```typescript
 /**
- * The parameters sent in file create requests/notifications.
+ * The parameters sent in notifications/requests for user-initiated creation of files.
  */
 export interface CreateFilesParams {
 	/**
@@ -3272,51 +3272,51 @@ _Response_:
 * result:`WorkspaceEdit` \| `null`
 * error: code and message set in case an exception happens during the `willCreateFiles` request.
 
-#### <a href="#workspace_didCreateFiles" name="workspace_didCreateFiles" class="anchor">DidCreateFiles Notification (:arrow_right:)</a>
+#### <a href="#window_didCreateFiles" name="window_didCreateFiles" class="anchor">DidCreateFiles Notification (:arrow_right:)</a>
 
 The did create files notification is sent from the client to the server when files were created in the client.
 
 _Client Capability_:
-* property name (optional): `workspace.files.didCreate`
+* property name (optional): `window.fileOperations.didCreate`
 * property type: `boolean`
 
-The capability indicates that the client supports `workspace/didCreateFiles` notifications.
+The capability indicates that the client supports `window/didCreateFiles` notifications.
 
 _Server Capability_:
-* property name (optional): `workspace.files.didCreate`
+* property name (optional): `window.fileOperations.didCreate`
 * property type: `FileOperationRegistrationOptions`
 
-The capability indicates that the server is interested in `workspace/didCreateFiles` notifications.
+The capability indicates that the server is interested in CreateFiles` notifications.
 
 _Notification_:
-* method: 'workspace/didCreateFiles'
+* method: 'window/didCreateFiles'
 * params: `CreateFilesParams`
 
-#### <a href="#workspace_willRenameFiles" name="workspace_willRenameFiles" class="anchor">WillRenameFiles Request (:leftwards_arrow_with_hook:)</a>
+#### <a href="#window_willRenameFiles" name="window_willRenameFiles" class="anchor">WillRenameFiles Request (:leftwards_arrow_with_hook:)</a>
 
 The will rename files request is sent from the client to the server before files are actually renamed. The request can return a WorkspaceEdit which will be applied to workspace before the files are renamed. Please note that clients might drop results if computing the edit took too long or if a server constantly fails on this request. This is done to keep renames fast and reliable.
 
 _Client Capability_:
-* property name (optional): `workspace.files.willRename`
+* property name (optional): `window.fileOperations.willRename`
 * property type: `boolean`
 
-The capability indicates that the client supports `workspace/willRenameFiles` requests.
+The capability indicates that the client supports `window/willRenameFiles` requests.
 
 _Server Capability_:
-* property name (optional): `workspace.files.willRename`
+* property name (optional): `window.fileOperations.willRename`
 * property type: `FileOperationRegistrationOptions`
 
-The capability indicates that the server is interested in `workspace/willRenameFiles` requests.
+The capability indicates that the server is interested in `window/willRenameFiles` requests.
 
 _Registration Options_: none
 
 _Request_:
-* method: 'workspace/willRenameFiles'
+* method: 'window/willRenameFiles'
 * params: `RenameFilesParams` defined as follows:
 
 ```typescript
 /**
- * The parameters sent in file rename requests/notifications.
+ * The parameters sent in notifications/requests for user-initiated renames of files.
  */
 export interface RenameFilesParams {
 	/**
@@ -3344,51 +3344,51 @@ _Response_:
 * result:`WorkspaceEdit` \| `null`
 * error: code and message set in case an exception happens during the `willRenameFiles` request.
 
-#### <a href="#workspace_didRenameFiles" name="workspace_didRenameFiles" class="anchor">DidRenameFiles Notification (:arrow_right:)</a>
+#### <a href="#window_didRenameFiles" name="window_didRenameFiles" class="anchor">DidRenameFiles Notification (:arrow_right:)</a>
 
 The did rename files notification is sent from the client to the server when files were renamed in the client.
 
 _Client Capability_:
-* property name (optional): `workspace.files.didRename`
+* property name (optional): `window.fileOperations.didRename`
 * property type: `boolean`
 
-The capability indicates that the client supports `workspace/didRenameFiles` notifications.
+The capability indicates that the client supports `window/didRenameFiles` notifications.
 
 _Server Capability_:
-* property name (optional): `workspace.files.didRename`
+* property name (optional): `window.fileOperations.didRename`
 * property type: `FileOperationRegistrationOptions`
 
-The capability indicates that the server is interested in `workspace/didRenameFiles` notifications.
+The capability indicates that the server is interested in `window/didRenameFiles` notifications.
 
 _Notification_:
-* method: 'workspace/didRenameFiles'
+* method: 'window/didRenameFiles'
 * params: `RenameFilesParams`
 
-#### <a href="#workspace_willDeleteFiles" name="workspace_willDeleteFiles" class="anchor">WillDeleteFiles Request (:leftwards_arrow_with_hook:)</a>
+#### <a href="#window_willDeleteFiles" name="window_willDeleteFiles" class="anchor">WillDeleteFiles Request (:leftwards_arrow_with_hook:)</a>
 
 The will delete files request is sent from the client to the server before files are actually deleted. The request can return a WorkspaceEdit which will be applied to workspace before the files are deleted. Please note that clients might drop results if computing the edit took too long or if a server constantly fails on this request. This is done to keep deletes fast and reliable.
 
 _Client Capability_:
-* property name (optional): `workspace.files.willDelete`
+* property name (optional): `window.fileOperations.willDelete`
 * property type: `boolean`
 
-The capability indicates that the client supports `workspace/willDeleteFiles` requests.
+The capability indicates that the client supports `window/willDeleteFiles` requests.
 
 _Server Capability_:
-* property name (optional): `workspace.files.willDelete`
+* property name (optional): `window.fileOperations.willDelete`
 * property type: `FileOperationRegistrationOptions`
 
-The capability indicates that the server is interested in `workspace/willDeleteFiles` requests.
+The capability indicates that the server is interested in `window/willDeleteFiles` requests.
 
 _Registration Options_: none
 
 _Request_:
-* method: 'workspace/willDeleteFiles'
+* method: 'window/willDeleteFiles'
 * params: `DeleteFilesParams` defined as follows:
 
 ```typescript
 /**
- * The parameters sent in file delete requests/notifications.
+ * The parameters sent in notifications/requests for user-initiated deletes of files.
  */
 export interface DeleteFilesParams {
 	/**
@@ -3411,24 +3411,24 @@ _Response_:
 * result:`WorkspaceEdit` \| `null`
 * error: code and message set in case an exception happens during the `willDeleteFiles` request.
 
-#### <a href="#workspace_didDeleteFiles" name="workspace_didDeleteFiles" class="anchor">DidDeleteFiles Notification (:arrow_right:)</a>
+#### <a href="#window_didDeleteFiles" name="window_didDeleteFiles" class="anchor">DidDeleteFiles Notification (:arrow_right:)</a>
 
 The did delete files notification is sent from the client to the server when files were deleted in the client.
 
 _Client Capability_:
-* property name (optional): `workspace.files.didDelete`
+* property name (optional): `window.fileOperations.didDelete`
 * property type: `boolean`
 
-The capability indicates that the client supports `workspace/didDeleteFiles` notifications.
+The capability indicates that the client supports `window/didDeleteFiles` notifications.
 
 _Server Capability_:
-* property name (optional): `workspace.files.didDelete`
+* property name (optional): `window.fileOperations.didDelete`
 * property type: `FileOperationRegistrationOptions`
 
-The capability indicates that the server is interested in `workspace/didDeleteFiles` notifications.
+The capability indicates that the server is interested in `window/didDeleteFiles` notifications.
 
 _Notification_:
-* method: 'workspace/didDeleteFiles'
+* method: 'window/didDeleteFiles'
 * params: `DeleteFilesParams`
 
 #### <a href="#textDocument_synchronization" name="textDocument_synchronization" class="anchor">Text Document Synchronization</a>
@@ -7801,9 +7801,9 @@ Servers usually support different communication channels (e.g. stdio, pipes, ...
 * Add support for code action resolve request.
 * Add support for diagnostic `data` property.
 * Add support for signature information `activeParameter` property.
-* Add support for `workspace/didCreateFiles` notifications and `workspace/willCreateFiles` requests.
-* Add support for `workspace/didRenameFiles` notifications and `workspace/willRenameFiles` requests.
-* Add support for `workspace/didDeleteFiles` notifications and `workspace/willDeleteFiles` requests.
+* Add support for `window/didCreateFiles` notifications and `window/willCreateFiles` requests.
+* Add support for `window/didRenameFiles` notifications and `window/willRenameFiles` requests.
+* Add support for `window/didDeleteFiles` notifications and `window/willDeleteFiles` requests.
 * Add client capability to signal whether the client normalizes line endings.
 * Add support to preserve additional attributes on `MessageActionItem`.
 * Add support to provide the clients locale in the initialize call.

--- a/_specifications/specification-3-16.md
+++ b/_specifications/specification-3-16.md
@@ -1985,7 +1985,7 @@ interface ClientCapabilities {
 			didCreate?: boolean;
 
 			/**
-			 * The client has support for willCreateFiles requests.
+			 * The client has support for sending willCreateFiles requests.
 			 */
 			willCreate?: boolean;
 
@@ -1995,7 +1995,7 @@ interface ClientCapabilities {
 			didRename?: boolean;
 
 			/**
-			 * The client has support for willRenameFiles requests.
+			 * The client has support for sending willRenameFiles requests.
 			 */
 			willRename?: boolean;
 
@@ -2005,7 +2005,7 @@ interface ClientCapabilities {
 			didDelete?: boolean;
 
 			/**
-			 * The client has support for willDeleteFiles requests.
+			 * The client has support for sending willDeleteFiles requests.
 			 */
 			willDelete?: boolean;
 		}
@@ -2325,32 +2325,32 @@ interface ServerCapabilities {
 		*/
 		fileOperations?: {
 			/**
-			* The server is interested in didCreateFiles notifications.
+			* The server is interested in receiving didCreateFiles notifications.
 			*/
 			didCreate?: FileOperationRegistrationOptions;
 
 			/**
-			* The server is interested in willCreateFiles requests.
+			* The server is interested in receiving willCreateFiles requests.
 			*/
 			willCreate?: FileOperationRegistrationOptions;
 
 			/**
-			* The server is interested in didRenameFiles notifications.
+			* The server is interested in receiving didRenameFiles notifications.
 			*/
 			didRename?: FileOperationRegistrationOptions;
 
 			/**
-			* The server is interested in willRenameFiles requests.
+			* The server is interested in receiving willRenameFiles requests.
 			*/
 			willRename?: FileOperationRegistrationOptions;
 
 			/**
-			* The server is interested in didDeleteFiles file notifications.
+			* The server is interested in receiving didDeleteFiles file notifications.
 			*/
 			didDelete?: FileOperationRegistrationOptions;
 
 			/**
-			* The server is interested in willDeleteFiles file requests.
+			* The server is interested in receiving willDeleteFiles file requests.
 			*/
 			willDelete?: FileOperationRegistrationOptions;
 		}

--- a/_specifications/specification-3-16.md
+++ b/_specifications/specification-3-16.md
@@ -3355,6 +3355,10 @@ _Server Capability_:
 
 ```typescript
 interface FileOperationRegistrationOptions {
+	patterns: FileOperationPattern[];
+}
+
+interface FileOperationPattern {
 	/**
 	 * The glob pattern to match. Glob patterns can have the following syntax:
 	 * - `*` to match one or more characters in a path segment
@@ -3363,9 +3367,15 @@ interface FileOperationRegistrationOptions {
 	 * - `{}` to group conditions (e.g. `**​/*.{ts,js}` matches all TypeScript and JavaScript files)
 	 * - `[]` to declare a range of characters to match in a path segment (e.g., `example.[0-9]` to match on `example.0`, `example.1`, …)
 	 * - `[!...]` to negate a range of characters to match in a path segment (e.g., `example.[!0-9]` to match on `example.a`, `example.b`, but not `example.0`)
-	 * - `/` suffix to match only folders (e.g. `**{/,*.dart}` matches all Dart files and all folders)
 	 */
-	globPattern: string;
+	glob: string;
+
+	/**
+	 * Whether to match files or folders with this pattern.
+	 *
+	 * Matches both if undefined.
+	 */
+	matches?: 'file' | 'folder';
 }
 ```
 

--- a/_specifications/specification-3-16.md
+++ b/_specifications/specification-3-16.md
@@ -1702,14 +1702,9 @@ interface ClientCapabilities {
 			didCreate?: boolean;
 
 			/**
-			 * The client has support for willCreateFiles notifications.
-			 */
-			willCreate?: boolean;
-
-			/**
 			 * The client has support for willCreateFiles requests.
 			 */
-			willCreateWaitUntil?: boolean;
+			willCreate?: boolean;
 
 			/**
 			 * The client has support for sending didRenameFiles notifications.
@@ -1717,14 +1712,9 @@ interface ClientCapabilities {
 			didRename?: boolean;
 
 			/**
-			 * The client has support for willRenameFiles notifications.
-			 */
-			willRename?: boolean;
-
-			/**
 			 * The client has support for willRenameFiles requests.
 			 */
-			willRenameWaitUntil?: boolean;
+			willRename?: boolean;
 
 			/**
 			 * The client has support for sending didDeleteFiles notifications.
@@ -1732,14 +1722,9 @@ interface ClientCapabilities {
 			didDelete?: boolean;
 
 			/**
-			 * The client has support for willDeleteFiles notifications.
-			 */
-			willDelete?: boolean;
-
-			/**
 			 * The client has support for willDeleteFiles requests.
 			 */
-			willDeleteWaitUntil?: boolean;
+			willDelete?: boolean;
 		}
 
 		/**
@@ -2028,14 +2013,9 @@ interface ServerCapabilities {
 		didCreate?: boolean;
 
 		/**
-		* The server is interested in willCreateFiles notifications.
+		* The server is interested in willCreateFiles requests.
 		*/
 		willCreate?: boolean;
-
-		/**
-		* The server is interested in willCreateFilesWaitUntil requests.
-		*/
-		willCreateWaitUntil?: boolean;
 
 		/**
 		* The server is interested in didRenameFiles notifications.
@@ -2043,14 +2023,9 @@ interface ServerCapabilities {
 		didRename?: boolean;
 
 		/**
-		* The server is interested in willRenameFiles notifications.
+		* The server is interested in willRenameFiles requests.
 		*/
 		willRename?: boolean;
-
-		/**
-		* The server is interested in willRenameFilesWaitUntil requests.
-		*/
-		willRenameWaitUntil?: boolean;
 
 		/**
 		* The server is interested in didDeleteFiles file notifications.
@@ -2058,14 +2033,9 @@ interface ServerCapabilities {
 		didDelete?: boolean;
 
 		/**
-		* The server is interested in willDeleteFiles file notifications.
+		* The server is interested in willDeleteFiles file requests.
 		*/
 		willDelete?: boolean;
-
-		/**
-		* The server is interested in willDeleteFilesWaitUntil requests.
-		*/
-		willDeleteWaitUntil?: boolean;
 	}
 
 	/**
@@ -2934,25 +2904,25 @@ export interface ApplyWorkspaceEditResponse {
 ```
 * error: code and message set in case an exception happens during the request.
 
-#### <a href="#workspace_willCreateFiles" name="workspace_willCreate" class="anchor">WillCreateFiles Notification (:arrow_right:)</a>
+#### <a href="#workspace_willCreateFiles" name="workspace_willCreateFiles" class="anchor">WillCreateFiles Request (:leftwards_arrow_with_hook:)</a>
 
-The will create files notification is sent from the client to the server before files are actually created.
+The will create files request is sent from the client to the server before files are actually created. The request can return a WorkspaceEdit which will be applied to workspace before the files are created. Please note that clients might drop results if computing the edit took too long or if a server constantly fails on this request. This is done to keep creates fast and reliable.
 
 _Client Capability_:
-* property name (optional): `workspace.files.willCreate`
+* property name (optional): `workspace.files.willCreateWait`
 * property type: `boolean`
 
-The capability indicates that the client supports `workspace/willCreateFiles` notifications.
+The capability indicates that the client supports `workspace/willCreateFiles` requests.
 
 _Server Capability_:
 * property name (optional): `workspace.files.willCreate`
-* property type: `bool`
+* property type: `boolean`
 
-The capability indicates that the server is interested in `workspace/willCreateFiles` notifications.
+The capability indicates that the server is interested in `workspace/willCreateFiles` requests.
 
 _Registration Options_: none
 
-_Notification_:
+_Request_:
 * method: 'workspace/willCreateFiles'
 * params: `CreateFilesParams` defined as follows:
 
@@ -2977,31 +2947,9 @@ export namespace FileCreate {
 }
 ```
 
-#### <a href="#workspace_willCreateFilesWaitUntil" name="workspace_willCreateFilesWaitUntil" class="anchor">WillCreateFilesWaitUntil Request (:leftwards_arrow_with_hook:)</a>
-
-The will create files wait until request is sent from the client to the server before files are actually created. The request can return a WorkspaceEdit which will be applied to workspace before the files are created. Please note that clients might drop results if computing the edit took too long or if a server constantly fails on this request. This is done to keep creates fast and reliable.
-
-_Client Capability_:
-* property name (optional): `workspace.files.willCreateWaitUntil`
-* property type: `boolean`
-
-The capability indicates that the client supports `workspace/willCreateFilesWaitUntil` requests.
-
-_Server Capability_:
-* property name (optional): `workspace.files.willCreateWaitUntil`
-* property type: `boolean`
-
-The capability indicates that the server is interested in `workspace/willCreateFilesWaitUntil` requests.
-
-_Registration Options_: none
-
-_Request_:
-* method: 'workspace/willCreateFilesWaitUntil'
-* params: `CreateFilesParams`
-
 _Response_:
 * result:`WorkspaceEdit` \| `null`
-* error: code and message set in case an exception happens during the `willCreateFilesWaitUntil` request.
+* error: code and message set in case an exception happens during the `willCreateFiles` request.
 
 #### <a href="#workspace_didCreateFiles" name="workspace_didCreateFiles" class="anchor">DidCreateFiles Notification (:arrow_right:)</a>
 
@@ -3023,25 +2971,25 @@ _Notification_:
 * method: 'workspace/didCreateFiles'
 * params: `CreateFilesParams`
 
-#### <a href="#workspace_willRenameFiles" name="workspace_willRename" class="anchor">WillRenameFiles Notification (:arrow_right:)</a>
+#### <a href="#workspace_willRenameFiles" name="workspace_willRenameFiles" class="anchor">WillRenameFiles Request (:leftwards_arrow_with_hook:)</a>
 
-The will rename files notification is sent from the client to the server before files are actually renamed.
+The will rename files request is sent from the client to the server before files are actually renamed. The request can return a WorkspaceEdit which will be applied to workspace before the files are renamed. Please note that clients might drop results if computing the edit took too long or if a server constantly fails on this request. This is done to keep renames fast and reliable.
 
 _Client Capability_:
 * property name (optional): `workspace.files.willRename`
 * property type: `boolean`
 
-The capability indicates that the client supports `workspace/willRenameFiles` notifications.
+The capability indicates that the client supports `workspace/willRenameFiles` requests.
 
 _Server Capability_:
 * property name (optional): `workspace.files.willRename`
-* property type: `bool`
+* property type: `boolean`
 
-The capability indicates that the server is interested in `workspace/willRenameFiles` notifications.
+The capability indicates that the server is interested in `workspace/willRenameFiles` requests.
 
 _Registration Options_: none
 
-_Notification_:
+_Request_:
 * method: 'workspace/willRenameFiles'
 * params: `RenameFilesParams` defined as follows:
 
@@ -3071,31 +3019,9 @@ export namespace FileRename {
 }
 ```
 
-#### <a href="#workspace_willRenameFilesWaitUntil" name="workspace_willRenameFilesWaitUntil" class="anchor">WillRenameFilesWaitUntil Request (:leftwards_arrow_with_hook:)</a>
-
-The will rename files wait until request is sent from the client to the server before files are actually renamed. The request can return a WorkspaceEdit which will be applied to workspace before the files are renamed. Please note that clients might drop results if computing the edit took too long or if a server constantly fails on this request. This is done to keep renames fast and reliable.
-
-_Client Capability_:
-* property name (optional): `workspace.files.willRenameWaitUntil`
-* property type: `boolean`
-
-The capability indicates that the client supports `workspace/willRenameFilesWaitUntil` requests.
-
-_Server Capability_:
-* property name (optional): `workspace.files.willRenameWaitUntil`
-* property type: `boolean`
-
-The capability indicates that the server is interested in `workspace/willRenameFilesWaitUntil` requests.
-
-_Registration Options_: none
-
-_Request_:
-* method: 'workspace/willRenameFilesWaitUntil'
-* params: `RenameFilesParams`
-
 _Response_:
 * result:`WorkspaceEdit` \| `null`
-* error: code and message set in case an exception happens during the `willRenameFilesWaitUntil` request.
+* error: code and message set in case an exception happens during the `willRenameFiles` request.
 
 #### <a href="#workspace_didRenameFiles" name="workspace_didRenameFiles" class="anchor">DidRenameFiles Notification (:arrow_right:)</a>
 
@@ -3117,25 +3043,25 @@ _Notification_:
 * method: 'workspace/didRenameFiles'
 * params: `RenameFilesParams`
 
-#### <a href="#workspace_willDeleteFiles" name="workspace_willDelete" class="anchor">WillDeleteFiles Notification (:arrow_right:)</a>
+#### <a href="#workspace_willDeleteFiles" name="workspace_willDeleteFiles" class="anchor">WillDeleteFiles Request (:leftwards_arrow_with_hook:)</a>
 
-The will delete files notification is sent from the client to the server before files are actually deleted.
+The will delete files request is sent from the client to the server before files are actually deleted. The request can return a WorkspaceEdit which will be applied to workspace before the files are deleted. Please note that clients might drop results if computing the edit took too long or if a server constantly fails on this request. This is done to keep deletes fast and reliable.
 
 _Client Capability_:
 * property name (optional): `workspace.files.willDelete`
 * property type: `boolean`
 
-The capability indicates that the client supports `workspace/willDeleteFiles` notifications.
+The capability indicates that the client supports `workspace/willDeleteFiles` requests.
 
 _Server Capability_:
 * property name (optional): `workspace.files.willDelete`
-* property type: `bool`
+* property type: `boolean`
 
-The capability indicates that the server is interested in `workspace/willDeleteFiles` notifications.
+The capability indicates that the server is interested in `workspace/willDeleteFiles` requests.
 
 _Registration Options_: none
 
-_Notification_:
+_Request_:
 * method: 'workspace/willDeleteFiles'
 * params: `DeleteFilesParams` defined as follows:
 
@@ -3160,31 +3086,9 @@ export namespace FileDelete {
 }
 ```
 
-#### <a href="#workspace_willDeleteFilesWaitUntil" name="workspace_willDeleteFilesWaitUntil" class="anchor">WillDeleteFilesWaitUntil Request (:leftwards_arrow_with_hook:)</a>
-
-The will delete files wait until request is sent from the client to the server before files are actually deleted. The request can return a WorkspaceEdit which will be applied to workspace before the files are deleted. Please note that clients might drop results if computing the edit took too long or if a server constantly fails on this request. This is done to keep deletes fast and reliable.
-
-_Client Capability_:
-* property name (optional): `workspace.files.willDeleteWaitUntil`
-* property type: `boolean`
-
-The capability indicates that the client supports `workspace/willDeleteFilesWaitUntil` requests.
-
-_Server Capability_:
-* property name (optional): `workspace.files.willDeleteWaitUntil`
-* property type: `boolean`
-
-The capability indicates that the server is interested in `workspace/willDeleteFilesWaitUntil` requests.
-
-_Registration Options_: none
-
-_Request_:
-* method: 'workspace/willDeleteFilesWaitUntil'
-* params: `DeleteFilesParams`
-
 _Response_:
 * result:`WorkspaceEdit` \| `null`
-* error: code and message set in case an exception happens during the `willDeleteFilesWaitUntil` request.
+* error: code and message set in case an exception happens during the `willDeleteFiles` request.
 
 #### <a href="#workspace_didDeleteFiles" name="workspace_didDeleteFiles" class="anchor">DidDeleteFiles Notification (:arrow_right:)</a>
 
@@ -7327,9 +7231,9 @@ Language servers usually run in a separate process and client communicate with t
 * Add support for code action resolve request.
 * Add support for diagnostic `data` property.
 * Add support for signature information `activeParameter` property.
-* Add support for `workspace/onWillCreateFiles`, `workspace/onWillCreateFilesWaitUntil` and `workspace/onDidCreateFiles`
-* Add support for `workspace/onWillRenameFiles`, `workspace/onWillRenameFilesWaitUntil` and `workspace/onDidRenameFiles`
-* Add support for `workspace/onWillDeleteFiles`, `workspace/onWillDeleteFilesWaitUntil` and `workspace/onDidDeleteFiles`
+* Add support for `workspace/onDidCreateFiles`, `workspace/onWillCreateFiles`
+* Add support for `workspace/onDidRenameFiles`, `workspace/onWillRenameFiles`
+* Add support for `workspace/onDidDeleteFiles`, `workspace/onWillDeleteFiles`
 
 #### <a href="#version_3_15_0" name="version_3_15_0" class="anchor">3.15.0 (01/14/2020)</a>
 

--- a/_specifications/specification-3-16.md
+++ b/_specifications/specification-3-16.md
@@ -1697,19 +1697,49 @@ interface ClientCapabilities {
 		*/
 		files?: {
 			/**
-			 * The client has support for sending didRename file notifications.
+			 * The client has support for sending didCreateFiles notifications.
+			 */
+			didCreate?: boolean;
+
+			/**
+			 * The client has support for willCreateFiles notifications.
+			 */
+			willCreate?: boolean;
+
+			/**
+			 * The client has support for willCreateFiles requests.
+			 */
+			willCreateWaitUntil?: boolean;
+
+			/**
+			 * The client has support for sending didRenameFiles notifications.
 			 */
 			didRename?: boolean;
 
 			/**
-			 * The client has support for willRename file notifications.
+			 * The client has support for willRenameFiles notifications.
 			 */
 			willRename?: boolean;
 
 			/**
-			 * The client has support for willRename files requests.
+			 * The client has support for willRenameFiles requests.
 			 */
 			willRenameWaitUntil?: boolean;
+
+			/**
+			 * The client has support for sending didDeleteFiles notifications.
+			 */
+			didDelete?: boolean;
+
+			/**
+			 * The client has support for willDeleteFiles notifications.
+			 */
+			willDelete?: boolean;
+
+			/**
+			 * The client has support for willDeleteFiles requests.
+			 */
+			willDeleteWaitUntil?: boolean;
 		}
 
 		/**
@@ -1993,6 +2023,21 @@ interface ServerCapabilities {
 	*/
 	files?: {
 		/**
+		* The server is interested in didCreateFiles notifications.
+		*/
+		didCreate?: boolean;
+
+		/**
+		* The server is interested in willCreateFiles notifications.
+		*/
+		willCreate?: boolean;
+
+		/**
+		* The server is interested in willCreateFilesWaitUntil requests.
+		*/
+		willCreateWaitUntil?: boolean;
+
+		/**
 		* The server is interested in didRenameFiles notifications.
 		*/
 		didRename?: boolean;
@@ -2006,6 +2051,21 @@ interface ServerCapabilities {
 		* The server is interested in willRenameFilesWaitUntil requests.
 		*/
 		willRenameWaitUntil?: boolean;
+
+		/**
+		* The server is interested in didDeleteFiles file notifications.
+		*/
+		didDelete?: boolean;
+
+		/**
+		* The server is interested in willDeleteFiles file notifications.
+		*/
+		willDelete?: boolean;
+
+		/**
+		* The server is interested in willDeleteFilesWaitUntil requests.
+		*/
+		willDeleteWaitUntil?: boolean;
 	}
 
 	/**
@@ -2874,6 +2934,95 @@ export interface ApplyWorkspaceEditResponse {
 ```
 * error: code and message set in case an exception happens during the request.
 
+#### <a href="#workspace_willCreateFiles" name="workspace_willCreate" class="anchor">WillCreateFiles Notification (:arrow_right:)</a>
+
+The will create files notification is sent from the client to the server before files are actually created.
+
+_Client Capability_:
+* property name (optional): `workspace.files.willCreate`
+* property type: `boolean`
+
+The capability indicates that the client supports `workspace/willCreateFiles` notifications.
+
+_Server Capability_:
+* property name (optional): `workspace.files.willCreate`
+* property type: `bool`
+
+The capability indicates that the server is interested in `workspace/willCreateFiles` notifications.
+
+_Registration Options_: none
+
+_Notification_:
+* method: 'workspace/willCreateFiles'
+* params: `CreateFilesParams` defined as follows:
+
+```typescript
+/**
+ * The parameters sent in file create requests/notifications.
+ */
+export interface CreateFilesParams {
+	/**
+	 * An array of all files/folders created in this operation.
+	 */
+	files: FileCreate[];
+}
+/**
+ * Represents information on a file/folder create.
+ */
+export namespace FileCreate {
+	/**
+	 * A file:// URI for the location of the file/folder being created.
+	 */
+	uri: string;
+}
+```
+
+#### <a href="#workspace_willCreateFilesWaitUntil" name="workspace_willCreateFilesWaitUntil" class="anchor">WillCreateFilesWaitUntil Request (:leftwards_arrow_with_hook:)</a>
+
+The will create files wait until request is sent from the client to the server before files are actually created. The request can return a WorkspaceEdit which will be applied to workspace before the files are created. Please note that clients might drop results if computing the edit took too long or if a server constantly fails on this request. This is done to keep creates fast and reliable.
+
+_Client Capability_:
+* property name (optional): `workspace.files.willCreateWaitUntil`
+* property type: `boolean`
+
+The capability indicates that the client supports `workspace/willCreateFilesWaitUntil` requests.
+
+_Server Capability_:
+* property name (optional): `workspace.files.willCreateWaitUntil`
+* property type: `boolean`
+
+The capability indicates that the server is interested in `workspace/willCreateFilesWaitUntil` requests.
+
+_Registration Options_: none
+
+_Request_:
+* method: 'workspace/willCreateFilesWaitUntil'
+* params: `CreateFilesParams`
+
+_Response_:
+* result:`WorkspaceEdit` \| `null`
+* error: code and message set in case an exception happens during the `willCreateFilesWaitUntil` request.
+
+#### <a href="#workspace_didCreateFiles" name="workspace_didCreateFiles" class="anchor">DidCreateFiles Notification (:arrow_right:)</a>
+
+The did create files notification is sent from the client to the server when files were created in the client.
+
+_Client Capability_:
+* property name (optional): `workspace.files.didCreate`
+* property type: `boolean`
+
+The capability indicates that the client supports `workspace/didCreateFiles` notifications.
+
+_Server Capability_:
+* property name (optional): `workspace.files.didCreate`
+* property type: `boolean`
+
+The capability indicates that the server is interested in `workspace/didCreateFiles` notifications.
+
+_Notification_:
+* method: 'workspace/didCreateFiles'
+* params: `CreateFilesParams`
+
 #### <a href="#workspace_willRenameFiles" name="workspace_willRename" class="anchor">WillRenameFiles Notification (:arrow_right:)</a>
 
 The will rename files notification is sent from the client to the server before files are actually renamed.
@@ -2967,6 +3116,95 @@ The capability indicates that the server is interested in `workspace/didRenameFi
 _Notification_:
 * method: 'workspace/didRenameFiles'
 * params: `RenameFilesParams`
+
+#### <a href="#workspace_willDeleteFiles" name="workspace_willDelete" class="anchor">WillDeleteFiles Notification (:arrow_right:)</a>
+
+The will delete files notification is sent from the client to the server before files are actually deleted.
+
+_Client Capability_:
+* property name (optional): `workspace.files.willDelete`
+* property type: `boolean`
+
+The capability indicates that the client supports `workspace/willDeleteFiles` notifications.
+
+_Server Capability_:
+* property name (optional): `workspace.files.willDelete`
+* property type: `bool`
+
+The capability indicates that the server is interested in `workspace/willDeleteFiles` notifications.
+
+_Registration Options_: none
+
+_Notification_:
+* method: 'workspace/willDeleteFiles'
+* params: `DeleteFilesParams` defined as follows:
+
+```typescript
+/**
+ * The parameters sent in file delete requests/notifications.
+ */
+export interface DeleteFilesParams {
+	/**
+	 * An array of all files/folders deleted in this operation.
+	 */
+	files: FileDelete[];
+}
+/**
+ * Represents information on a file/folder delete.
+ */
+export namespace FileDelete {
+	/**
+	 * A file:// URI for the location of the file/folder being deleted.
+	 */
+	uri: string;
+}
+```
+
+#### <a href="#workspace_willDeleteFilesWaitUntil" name="workspace_willDeleteFilesWaitUntil" class="anchor">WillDeleteFilesWaitUntil Request (:leftwards_arrow_with_hook:)</a>
+
+The will delete files wait until request is sent from the client to the server before files are actually deleted. The request can return a WorkspaceEdit which will be applied to workspace before the files are deleted. Please note that clients might drop results if computing the edit took too long or if a server constantly fails on this request. This is done to keep deletes fast and reliable.
+
+_Client Capability_:
+* property name (optional): `workspace.files.willDeleteWaitUntil`
+* property type: `boolean`
+
+The capability indicates that the client supports `workspace/willDeleteFilesWaitUntil` requests.
+
+_Server Capability_:
+* property name (optional): `workspace.files.willDeleteWaitUntil`
+* property type: `boolean`
+
+The capability indicates that the server is interested in `workspace/willDeleteFilesWaitUntil` requests.
+
+_Registration Options_: none
+
+_Request_:
+* method: 'workspace/willDeleteFilesWaitUntil'
+* params: `DeleteFilesParams`
+
+_Response_:
+* result:`WorkspaceEdit` \| `null`
+* error: code and message set in case an exception happens during the `willDeleteFilesWaitUntil` request.
+
+#### <a href="#workspace_didDeleteFiles" name="workspace_didDeleteFiles" class="anchor">DidDeleteFiles Notification (:arrow_right:)</a>
+
+The did delete files notification is sent from the client to the server when files were deleted in the client.
+
+_Client Capability_:
+* property name (optional): `workspace.files.didDelete`
+* property type: `boolean`
+
+The capability indicates that the client supports `workspace/didDeleteFiles` notifications.
+
+_Server Capability_:
+* property name (optional): `workspace.files.didDelete`
+* property type: `boolean`
+
+The capability indicates that the server is interested in `workspace/didDeleteFiles` notifications.
+
+_Notification_:
+* method: 'workspace/didDeleteFiles'
+* params: `DeleteFilesParams`
 
 #### <a href="#textDocument_synchronization" name="textDocument_synchronization" class="anchor">Text Document Synchronization</a>
 

--- a/_specifications/specification-3-16.md
+++ b/_specifications/specification-3-16.md
@@ -2960,7 +2960,7 @@ export interface CreateFilesParams {
 /**
  * Represents information on a file/folder create.
  */
-export namespace FileCreate {
+export interface FileCreate {
 	/**
 	 * A file:// URI for the location of the file/folder being created.
 	 */
@@ -3028,7 +3028,7 @@ export interface RenameFilesParams {
 /**
  * Represents information on a file/folder rename.
  */
-export namespace FileRename {
+export interface FileRename {
 	/**
 	 * A file:// URI for the original location of the file/folder being renamed.
 	 */
@@ -3099,7 +3099,7 @@ export interface DeleteFilesParams {
 /**
  * Represents information on a file/folder delete.
  */
-export namespace FileDelete {
+export interface FileDelete {
 	/**
 	 * A file:// URI for the location of the file/folder being deleted.
 	 */


### PR DESCRIPTION
@dbaeumer this is a first go at  #984 using `WaitUntil` requests. It currently only includes rename, but we can duplicate for create/delete once these are good if required.

Some things I wasn't sure about:

- Should the capabilities just be bools, or additional nested objects for easier extending in future (or would they just be changed to `boolean | {/*...*/}`?
- Is `workspace` the right place for these? Save etc. are in `textDocument/` but these could be folder renames so there's no specific document.
- Is it valid to have no registration options? Servers should be able to opt in/out, but otherwise I don't think there's anything (I don't think using document selectors would make sense as it may force the client to scan down the whole tree for folder renames).
- Is v3.16.0 correct or may that release before this is done?

(I haven't tried to generate my code from these changes yet, but I'd like to do so before this is merged - but I figured there may be some iteration first)