### PR TITLE
Fix typo and LSIF code block color contrast

### DIFF
--- a/css/main.scss
+++ b/css/main.scss
@@ -107,11 +107,11 @@ pre[class=highlight] {
 }
 
 .highlight .c {
-	color: #929292
+	color: #525151
 }
 
 .highlight .err {
-	color: #929292
+	color: #525151
 }
 
 .highlight .k {
@@ -123,7 +123,7 @@ pre[class=highlight] {
 }
 
 .highlight .n {
-	color: #929292
+	color: #525151
 }
 
 .highlight .o {
@@ -131,23 +131,23 @@ pre[class=highlight] {
 }
 
 .highlight .p {
-	color: #929292
+	color: #525151
 }
 
 .highlight .cm {
-	color: #929292
+	color: #525151
 }
 
 .highlight .cp {
-	color: #929292
+	color: #525151
 }
 
 .highlight .c1 {
-	color: #929292
+	color: #525151
 }
 
 .highlight .cs {
-	color: #929292
+	color: #525151
 }
 
 .highlight .gd {
@@ -164,11 +164,11 @@ pre[class=highlight] {
 }
 
 .highlight .gi {
-	color: #718C00
+	color: #5b7201
 }
 
 .highlight .gp {
-	color: #718C00;
+	color: #5b7201;
 	font-weight: bold
 }
 
@@ -206,7 +206,7 @@ pre[class=highlight] {
 }
 
 .highlight .ld {
-	color: #718C00
+	color: #5b7201
 }
 
 .highlight .m {
@@ -214,7 +214,7 @@ pre[class=highlight] {
 }
 
 .highlight .s {
-	color: #718C00
+	color: #5b7201
 }
 
 .highlight .na {
@@ -298,7 +298,7 @@ pre[class=highlight] {
 }
 
 .highlight .sb {
-	color: #718C00
+	color: #5b7201
 }
 
 .highlight .sc {
@@ -306,7 +306,7 @@ pre[class=highlight] {
 }
 
 .highlight .sd {
-	color: #929292
+	color: #525151
 }
 
 .highlight .s2 {
@@ -318,7 +318,7 @@ pre[class=highlight] {
 }
 
 .highlight .sh {
-	color: #718C00
+	color: #5b7201
 }
 
 .highlight .si {
@@ -326,19 +326,19 @@ pre[class=highlight] {
 }
 
 .highlight .sx {
-	color: #718C00
+	color: #5b7201
 }
 
 .highlight .sr {
-	color: #718C00
+	color: #5b7201
 }
 
 .highlight .s1 {
-	color: #718C00
+	color: #5b7201
 }
 
 .highlight .ss {
-	color: #718C00
+	color: #5b7201
 }
 
 .highlight .bp {

--- a/index.html
+++ b/index.html
@@ -70,7 +70,7 @@ layout: default
                     <div class="carousel-item">
                         <div class="row align-items-center">
                             <div class="col-lg-8">
-                                <img atl="VS IDE Rust code completion" src="img/vs-rust-code-complete.png" class="img-fluid rounded"/>
+                                <img alt="VS IDE Rust code completion" src="img/vs-rust-code-complete.png" class="img-fluid rounded"/>
                                 <p class="text-left"><i>Rust code complete in Visual Studio powered by the Rust LSP Server</i></p>
                             </div>
                         </div>


### PR DESCRIPTION
Fix typo in alt text.
Also tune more code block items after checking LSIF specification examples.