### PR TITLE
Add LspTypes for C# and clean up table.

### DIFF
--- a/_implementors/sdks.md
+++ b/_implementors/sdks.md
@@ -10,22 +10,23 @@ index: 3
 
 | Language | Maintainer | Repository |
 |------|--------|----------|
-| node.js | MS | [vscode-languageserver-node](https://github.com/Microsoft/vscode-languageserver-node)  |
+| C# | [Inomata Kentaro](https://github.com/matarillo/) | [LanguageServerProtocol](https://github.com/matarillo/LanguageServerProtocol)|
+| C# | [OmniSharp](http://www.omnisharp.net/) | [C#-LSP](https://github.com/OmniSharp/csharp-language-server-protocol)|
 | C# | MS | work in progress by [David Wilson](https://github.com/daviwil)  |
-| Java | Eclipse, TypeFox |  [Eclipse LSP4J](https://github.com/eclipse/lsp4j) |
+| C# | [Ken Domino](https://github.com/kaby76) | [LspTypes for C#](https://github.com/kaby76/lsp-types) |
+| C++ | [Kuafu](https://github.com/kuafuwang) | [LspCpp](https://github.com/kuafuwang/LspCpp)|
+| C++17 | [otreblan](https://github.com/otreblan) | [libclsp](https://github.com/otreblan/libclsp) (WIP)|
+| Go | [disposedtrolley](https://github.com/disposedtrolley) | [golsp-sdk](https://github.com/goodgophers/golsp-sdk) (WIP)|
+| Haskell | [Alan Zimmerman](https://github.com/alanz) | [Haskell-LSP](https://github.com/alanz/haskell-lsp)|
+| Haskell | [Luke Lau](https://github.com/Bubba) | [lsp-test](https://github.com/Bubba/lsp-test)|
 | Haxe | @nadako | [language-server-protocol-haxe](https://github.com/vshaxe/language-server-protocol-haxe)|
+| Java | Eclipse, TypeFox |  [Eclipse LSP4J](https://github.com/eclipse/lsp4j) |
+| node.js | MS | [vscode-languageserver-node](https://github.com/Microsoft/vscode-languageserver-node)  |
+| Objective-C | [Christopher Atlan](https://twitter.com/catlan) | [LSPKit](https://github.com/catlan/LSPKit)|
 | PHP | [Felix Becker](https://github.com/felixfbecker) | [php-language-server](https://github.com/felixfbecker/php-language-server)|
 | Python | [Open Law Library](http://www.openlawlib.org/) | [pygls](https://github.com/openlawlibrary/pygls)|
 | Python | [Yeger](https://github.com/yeger00) | [pylspclient](https://github.com/yeger00/pylspclient)|
 | Rust | [Bruno Medeiros](https://github.com/bruno-medeiros) | [RustLSP](https://github.com/RustDT/RustLSP)|
 | Rust | Bruno Medeiros and Markus Westerlind | [lsp-types](https://github.com/gluon-lang/lsp-types)
-| Haskell | [Alan Zimmerman](https://github.com/alanz) | [Haskell-LSP](https://github.com/alanz/haskell-lsp)|
-| Haskell | [Luke Lau](https://github.com/Bubba) | [lsp-test](https://github.com/Bubba/lsp-test)|
-| C# | [OmniSharp](http://www.omnisharp.net/) | [C#-LSP](https://github.com/OmniSharp/csharp-language-server-protocol)|
-| C# | [Inomata Kentaro](https://github.com/matarillo/) | [LanguageServerProtocol](https://github.com/matarillo/LanguageServerProtocol)|
-| Objective-C | [Christopher Atlan](https://twitter.com/catlan) | [LSPKit](https://github.com/catlan/LSPKit)|
 | Swift | [Chime](https://twitter.com/chimehq) | [SwiftLSPClient](https://github.com/chimehq/SwiftLSPClient)|
-| C++ | [Kuafu](https://github.com/kuafuwang) | [LspCpp](https://github.com/kuafuwang/LspCpp)|
-| Go | [disposedtrolley](https://github.com/disposedtrolley) | [golsp-sdk](https://github.com/goodgophers/golsp-sdk) (WIP)|
-| C++17 | [otreblan](https://github.com/otreblan) | [libclsp](https://github.com/otreblan/libclsp) (WIP)|
 {: .table .table-bordered .table-responsive}


### PR DESCRIPTION
I am adding here my LspTypes C# library, which implements every message parameter type in the 3.16 spec and works with VS2019, VSCode, Emacs lsp-emacs with my server [Antlrvsix](https://github.com/kaby76/AntlrVSIX). Other versions will be scraped directly from the online spec with a tool I will be writing because it took me a week to methodically hand-translate the spec into C#.

I cleaned up the table slightly by sorting it by the first column, which was done in the [servers table](https://microsoft.github.io/language-server-protocol/implementors/servers/). However, the link for "C# | MS | work in progress by David Wilson" is completely useless for people looking for resources to *actually implement code*. I suggest this row be deleted, or MS actually open-source whatever library that is referred to here.