### PR TITLE
`DocumentSymbol.detail?`: support `MarkupContent`

### DIFF
--- a/_specifications/specification-3-15.md
+++ b/_specifications/specification-3-15.md
@@ -4441,11 +4441,15 @@ export interface DocumentSymbolClientCapabilities {
 		 */
 		valueSet?: SymbolKind[];
 	}
-
 	/**
 	 * The client supports hierarchical document symbols.
 	 */
 	hierarchicalDocumentSymbolSupport?: boolean;
+	
+	/**
+	 * The client supports `MarkupContent` in `DocumentSymbol.detail?`.
+	 */
+	detailMarkupSupport?: boolean;
 }
 ```
 
@@ -4531,9 +4535,11 @@ export interface DocumentSymbol {
 	name: string;
 
 	/**
-	 * More detail for this symbol, e.g the signature of a function.
+	 * More detail for this symbol, e.g the signature of a function. Can be
+     * `MarkupContent` only if the
+	 * client specifies `DocumentSymbolClientCapabilities.detailMarkupSupport?`.
 	 */
-	detail?: string;
+	detail?: string | MarkupContent;
 
 	/**
 	 * The kind of this symbol.

--- a/_specifications/specification-3-15.md
+++ b/_specifications/specification-3-15.md
@@ -4441,15 +4441,11 @@ export interface DocumentSymbolClientCapabilities {
 		 */
 		valueSet?: SymbolKind[];
 	}
+
 	/**
 	 * The client supports hierarchical document symbols.
 	 */
 	hierarchicalDocumentSymbolSupport?: boolean;
-	
-	/**
-	 * The client supports `MarkupContent` in `DocumentSymbol.detail?`.
-	 */
-	detailMarkupSupport?: boolean;
 }
 ```
 
@@ -4535,11 +4531,9 @@ export interface DocumentSymbol {
 	name: string;
 
 	/**
-	 * More detail for this symbol, e.g the signature of a function. Can be
-     * `MarkupContent` only if the
-	 * client specifies `DocumentSymbolClientCapabilities.detailMarkupSupport?`.
+	 * More detail for this symbol, e.g the signature of a function.
 	 */
-	detail?: string | MarkupContent;
+	detail?: string;
 
 	/**
 	 * The kind of this symbol.

--- a/_specifications/specification-3-16.md
+++ b/_specifications/specification-3-16.md
@@ -4876,11 +4876,12 @@ export interface DocumentSymbolClientCapabilities {
 	labelSupport?: boolean;
 
 	/**
-	 * The client supports `MarkupContent` in `DocumentSymbol.detail?`.
+     * The client supports the following content formats for `DocumentSymbol.detail?`.
+     * If this is unspecified, the client expects that field to be a plaintext string.
      *
      * @since 3.16.0
 	 */
-	detailMarkupSupport?: boolean;
+	detailMarkupFormat?: MarkupKind[];
 }
 ```
 
@@ -4992,7 +4993,8 @@ export interface DocumentSymbol {
 	 * More detail for this symbol, e.g the signature of a function.
      *
      * @since 3.16.0 Can be `MarkupContent` if the client specifies
-     * `DocumentSymbolClientCapabilities.detailMarkupSupport?`.
+     * `DocumentSymbolClientCapabilities.detailMarkupFormat?`. Supported markup
+     * types are also limited by that capability.
 	 */
 	detail?: string | MarkupContent;
 

--- a/_specifications/specification-3-16.md
+++ b/_specifications/specification-3-16.md
@@ -4874,6 +4874,13 @@ export interface DocumentSymbolClientCapabilities {
 	 * @since 3.16.0
 	 */
 	labelSupport?: boolean;
+
+	/**
+	 * The client supports `MarkupContent` in `DocumentSymbol.detail?`.
+     *
+     * @since 3.16.0
+	 */
+	detailMarkupSupport?: boolean;
 }
 ```
 
@@ -4983,8 +4990,11 @@ export interface DocumentSymbol {
 
 	/**
 	 * More detail for this symbol, e.g the signature of a function.
+     *
+     * @since 3.16.0 Can be `MarkupContent` if the client specifies
+     * `DocumentSymbolClientCapabilities.detailMarkupSupport?`.
 	 */
-	detail?: string;
+	detail?: string | MarkupContent;
 
 	/**
 	 * The kind of this symbol.


### PR DESCRIPTION
Fixes #1130.