### PR TITLE
Clarify SemanticTokenTypes.member is for functions

### DIFF
--- a/_specifications/specification-3-16.md
+++ b/_specifications/specification-3-16.md
@@ -6980,6 +6980,7 @@ export enum SemanticTokenTypes {
 	enumMember = 'enumMember',
 	event = 'event',
 	function = 'function',
+	/** A member function, or method. */
 	member = 'member',
 	macro = 'macro',
 	keyword = 'keyword',


### PR DESCRIPTION
Many languages including C and C++ define "member" to include consider instance variables/fields/data members.
However VSCode maps `member` to the textmate scope `entity.name.function.member`, i.e. method/member function.
The intent seems to be that methods are `member` and fields are `property`.

It may be too late to change the names to be less ambiguous, but at least we can clarify in the spec.