### PR TITLE
Remove duplicate URI definition

### DIFF
--- a/_specifications/specification-3-16.md
+++ b/_specifications/specification-3-16.md
@@ -310,10 +310,6 @@ The protocol currently assumes that one server serves one tool. There is current
 
 URI's are transferred as strings. The URI's format is defined in [http://tools.ietf.org/html/rfc3986](http://tools.ietf.org/html/rfc3986)
 
-```typescript
-type URI = string;
-```
-
 ```
   foo://example.com:8042/over/there?name=ferret#nose
   \_/   \______________/\_________/ \_________/ \__/


### PR DESCRIPTION
@dbaeumer spotted this when re-generating my classes. This was added in both https://github.com/microsoft/language-server-protocol/pull/1156 and bae2aaba5946c84cb28c28f4437711d744576ed7 so there were two. This removes the one added in my PR and leaves just yours.