### PR TITLE
Fix reference to insertReplaceSupport capability

### DIFF
--- a/_specifications/specification-3-17.md
+++ b/_specifications/specification-3-17.md
@@ -4747,8 +4747,8 @@ export interface CompletionItem {
 	 * existing text with a completion text. Since this can usually not be
 	 * predetermined by a server it can report both ranges. Clients need to
 	 * signal support for `InsertReplaceEdits` via the
-	 * `textDocument.completion.insertReplaceSupport` client capability
-	 * property.
+	 * `textDocument.completion.completionItem.insertReplaceSupport` client
+	 * capability property.
 	 *
 	 * *Note 1:* The text edit's range as well as both ranges from an insert
 	 * replace edit must be a [single line] and they must contain the position


### PR DESCRIPTION
This looked like an error - the field is in `completionItem` in the definition.