### PR TITLE
Update Crystal LSP implementations

### DIFF
--- a/_implementors/servers.md
+++ b/_implementors/servers.md
@@ -36,6 +36,7 @@ index: 1
 | [CodeQL](https://securitylab.github.com/tools/codeql) | [GitHub](https://github.com/github/codeql) | [codeql](https://github.com/github/codeql) | Java |
 | [CWL](https://www.commonwl.org/) | [Rabix](https://github.com/rabix) | [Benten](https://github.com/rabix/benten) | Python |
 | Crane PHP | [HvyIndustries](https://github.com/HvyIndustries) | [VS Code Extension](https://marketplace.visualstudio.com/items?itemName=HvyIndustries.crane) | TypeScript |
+| [Crystal](https://crystal-lang.org/)| [Elbaz Julien](https://github.com/elbywan) | [Crystalline](https://github.com/elbywan/crystalline) | Crystal |
 | [Crystal](https://crystal-lang.org/)| [Ryan L. Bell](https://github.com/kofno) | [Scry](https://github.com/crystal-lang-tools/scry) | Crystal |
 | [D](https://dlang.org) | [Jan Jurzitza](https://github.com/WebFreak001) | [serve-d](https://github.com/Pure-D/serve-d) | D |
 | [D](https://dlang.org) | [Laurent Tréguier](https://github.com/LaurentTreguier) | [D Language Server](https://github.com/d-language-server/dls) | D |

--- a/_implementors/servers.md
+++ b/_implementors/servers.md
@@ -36,7 +36,7 @@ index: 1
 | [CodeQL](https://securitylab.github.com/tools/codeql) | [GitHub](https://github.com/github/codeql) | [codeql](https://github.com/github/codeql) | Java |
 | [CWL](https://www.commonwl.org/) | [Rabix](https://github.com/rabix) | [Benten](https://github.com/rabix/benten) | Python |
 | Crane PHP | [HvyIndustries](https://github.com/HvyIndustries) | [VS Code Extension](https://marketplace.visualstudio.com/items?itemName=HvyIndustries.crane) | TypeScript |
-| [Crystal](https://crystal-lang.org/)| [Ryan L. Bell](https://github.com/kofno) | [scry](https://github.com/kofno/scry) | Crystal |
+| [Crystal](https://crystal-lang.org/)| [Ryan L. Bell](https://github.com/kofno) | [Scry](https://github.com/crystal-lang-tools/scry) | Crystal |
 | [D](https://dlang.org) | [Jan Jurzitza](https://github.com/WebFreak001) | [serve-d](https://github.com/Pure-D/serve-d) | D |
 | [D](https://dlang.org) | [Laurent Tréguier](https://github.com/LaurentTreguier) | [D Language Server](https://github.com/d-language-server/dls) | D |
 | Dart | [Dart Team](https://dart.dev/) | [Dart SDK](https://github.com/dart-lang/sdk/blob/master/pkg/analysis_server/tool/lsp_spec/README.md) | Dart |


### PR DESCRIPTION
* As far as I know, Crystalline works fine on newer Crystal versions even in Scry is not working
* Crystalline has been added to `awesome-crystal` as https://github.com/veelenga/awesome-crystal/pull/545
* I have updated VSCode extension Wiki as https://github.com/crystal-lang-tools/vscode-crystal-lang/wiki/Settings/_compare/9d305efc7b12230272e574e9ef008759c55beba4...b7e0500c1f67c90640b4d7eef28afad90c7be6b4 
* Scry repository looks moved to https://github.com/crystal-lang-tools/scry
* Documents describes `Scry`, it is correct naming rather than `scry`

@elbywan I believe Crystalline is the great tool for Crystal users. Thanks for the project 🙏 