### PR TITLE
Fix typo in LSP 3.16

### DIFF
--- a/_specifications/specification-3-16.md
+++ b/_specifications/specification-3-16.md
@@ -5843,7 +5843,7 @@ export interface SymbolInformation {
 	kind: SymbolKind;
 
 	/**
-	 * Tags for this completion item.
+	 * Tags for this symbol.
 	 *
 	 * @since 3.16.0
 	 */


### PR DESCRIPTION
Replace "completion item" with "symbol" for `tags` field description.