### PR TITLE
Support Type Hierarchy

### DIFF
--- a/_specifications/specification-3-17.md
+++ b/_specifications/specification-3-17.md
@@ -8302,7 +8302,7 @@ export interface TypeHierarchyItem {
 	 * Indicates if this item has subtypes. When `undefined` the subtypes
 	 * of this item have not been resolved yet.
 	 */
-	hasSubtypes?: boolean
+	hasSubtypes?: boolean;
 
 	/**
 	 * A data entry field that is preserved between a call hierarchy prepare and
@@ -8368,11 +8368,11 @@ The request is sent from the client to the server to resolve the inheritance tre
 * `TreeItem<T>` defined as follows:
 ```typescript
 export interface TreeItem<T> {
-	data: T,
+	data: T;
 	/**
 	 * The children of this TreeItem. When `undefined` the children have not been resolved yet.
 	 */
-	children?: TreeItem<T>[],
+	children?: TreeItem<T>[];
 }
 ```
 The result represents the inheritance tree related to the specified type hierarchy item. Only single inheritance can be represented this way. The root type is expected as the return value. The request doesn't define its own client and server capabilities. It is only issued if a server has the capability for `TypeHierarchyOptions/inheritanceTreeSuppport`.

--- a/_specifications/specification-3-17.md
+++ b/_specifications/specification-3-17.md
@@ -8197,8 +8197,6 @@ The type hierarchy request is sent from the client to the server to return a typ
   1. first a type hierarchy item is prepared for the given text document position.
   1. for a type hierarchy item the supertype or subtype type hierarchy items are resolved.
 
-In the first step, the `textDocument/prepareTypeHierarchy` request could have a unique, constant and optional `transactionId`. The following `typeHierarchy/supertypes` and `typeHierarchy/subtypes` requests in the second step could have the same `transactionId` in their params, which could be used to help indicate some cached data in the server.
-
 _Client Capability_:
 
 * property name (optional): `textDocument.typeHierarchy`
@@ -8223,6 +8221,10 @@ _Server Capability_:
 
 ```typescript
 export interface TypeHierarchyOptions extends WorkDoneProgressOptions {
+	/** 
+	 * The server supports for providing an inheritance tree.
+	 */
+	inheritanceTreeSuppport?: boolean;
 }
 ```
 
@@ -8243,7 +8245,6 @@ _Request_:
 ```typescript
 export interface TypeHierarchyPrepareParams extends TextDocumentPositionParams,
 	WorkDoneProgressParams {
-	transactionId?: integer | string;
 }
 ```
 
@@ -8293,7 +8294,9 @@ export interface TypeHierarchyItem {
 
 	/**
 	 * A data entry field that is preserved between a type hierarchy prepare and
-	 * supertypes or subtypes requests.
+	 * supertypes or subtypes requests. It could also be used to identify the 
+	 * type hierarchy in the server, helping improve the performance on 
+	 * resolving supertypes and subtypes.
 	 */
 	data?: unknown;
 }
@@ -8315,8 +8318,11 @@ _Request_:
 ```typescript
 export interface TypeHierarchySupertypesParams extends
 	WorkDoneProgressParams, PartialResultParams {
+	/**
+	 * If this is set to `true`, The request only asks for super class.
+	 */
+	classOnly?: boolean;
 	item: TypeHierarchyItem;
-	transactionId?: integer | string;
 }
 ```
 _Response_:
@@ -8340,7 +8346,6 @@ _Request_:
 export interface TypeHierarchySubtypesParams extends
 	WorkDoneProgressParams, PartialResultParams {
 	item: TypeHierarchyItem;
-	transactionId?: integer | string;
 }
 ```
 _Response_:

--- a/_specifications/specification-3-17.md
+++ b/_specifications/specification-3-17.md
@@ -8194,8 +8194,8 @@ export interface Moniker {
 
 The type hierarchy request is sent from the client to the server to return a type hierarchy for the language element of given text document positions. Will return `null` if the server couldn't infer a valid type from the position. The type hierarchy requests are executed in two steps:
 
-  1. first a type hierarchy item is prepared for the given text document position
-  1. the client request the server to resolve the given item with its supertypes or subtypes
+  1. first a type hierarchy item is prepared for the given text document position.
+  1. for a type hierarchy item the supertype or subtype type hierarchy items are resolved.
 
 In the first step, the `textDocument/prepareTypeHierarchy` request could have a unique, constant and optional `transactionId`. The following `typeHierarchy/supertypes` and `typeHierarchy/subtypes` requests in the second step could have the same `transactionId` in their params, which could be used to help indicate some cached data in the server.
 

--- a/_specifications/specification-3-17.md
+++ b/_specifications/specification-3-17.md
@@ -8224,7 +8224,7 @@ export interface TypeHierarchyOptions extends WorkDoneProgressOptions {
 	/** 
 	 * The server supports for providing an inheritance tree.
 	 */
-	inheritanceTreeSuppport?: boolean;
+	inheritanceTreeSupport?: boolean;
 }
 ```
 

--- a/_specifications/specification-3-17.md
+++ b/_specifications/specification-3-17.md
@@ -2431,7 +2431,7 @@ interface ServerCapabilities {
 	 *
 	 * @since 3.17.0
 	 */
-	typeHierarchyProvider?: TypeHierarchyOptions
+	typeHierarchyProvider?: boolean | TypeHierarchyOptions
 		| TypeHierarchyRegistrationOptions;
 
 	/**
@@ -8217,14 +8217,10 @@ interface TypeHierarchyClientCapabilities {
 _Server Capability_:
 
 * property name (optional): `typeHierarchyProvider`
-* property type: `TypeHierarchyOptions | TypeHierarchyRegistrationOptions` where `TypeHierarchyOptions` is defined as follows:
+* property type: `boolean | TypeHierarchyOptions | TypeHierarchyRegistrationOptions` where `TypeHierarchyOptions` is defined as follows:
 
 ```typescript
 export interface TypeHierarchyOptions extends WorkDoneProgressOptions {
-	/** 
-	 * The server supports for providing an inheritance tree.
-	 */
-	inheritanceTreeSupport?: boolean;
 }
 ```
 
@@ -8318,10 +8314,6 @@ _Request_:
 ```typescript
 export interface TypeHierarchySupertypesParams extends
 	WorkDoneProgressParams, PartialResultParams {
-	/**
-	 * If this is set to `true`, The request only asks for super class.
-	 */
-	classOnly?: boolean;
 	item: TypeHierarchyItem;
 }
 ```

--- a/_specifications/specification-3-17.md
+++ b/_specifications/specification-3-17.md
@@ -2431,7 +2431,7 @@ interface ServerCapabilities {
 	 *
 	 * @since 3.17.0
 	 */
-	typeHierarchyProvider?: boolean | TypeHierarchyOptions
+	typeHierarchyProvider?: TypeHierarchyOptions
 		| TypeHierarchyRegistrationOptions;
 
 	/**
@@ -8217,7 +8217,7 @@ interface TypeHierarchyClientCapabilities {
 _Server Capability_:
 
 * property name (optional): `typeHierarchyProvider`
-* property type: `boolean | TypeHierarchyOptions | TypeHierarchyRegistrationOptions` where `TypeHierarchyOptions` is defined as follows:
+* property type: `TypeHierarchyOptions | TypeHierarchyRegistrationOptions` where `TypeHierarchyOptions` is defined as follows:
 
 ```typescript
 export interface TypeHierarchyOptions extends WorkDoneProgressOptions {


### PR DESCRIPTION
There are three requests to support type hierarchy:
- `textDocument/prepareTypeHierarchy`: Sent from the client to the server to get the type hierarchy item from the given text document position
- `typeHierarchy/supertypes` and `typeHierarchy/subtypes`: Sent from the client to the server to resolve the given item's supertypes or subtypes
