### PR TITLE
Add CodeActionTriggerKind

### DIFF
--- a/_specifications/specification-3-17.md
+++ b/_specifications/specification-3-17.md
@@ -6152,6 +6152,27 @@ export interface CodeActionParams extends WorkDoneProgressParams,
 }
 
 /**
+ * The reason why code actions were requested.
+ * 
+ * @since 3.17.0
+ */
+export namespace CodeActionTriggerKind {
+	/**
+	 * Code actions were explicitly requested by the user or by an extension.
+	 */
+	export const Invoked: 1 = 1;
+
+	/**
+	 * Code actions were requested automatically.
+	 *
+	 * This typically happens when current selection in a file changes, but can
+	 * also be triggered when file content changes.
+	 */
+	export const Automatic: 2 = 2;
+}
+export type CodeActionTriggerKind = 1 | 2;
+
+/**
  * The kind of a code action.
  *
  * Kinds are a hierarchical list of identifiers separated by `.`,
@@ -6241,6 +6262,13 @@ export namespace CodeActionKind {
  * a code action is run.
  */
 export interface CodeActionContext {
+	/**
+	 * The reason why code actions were requested.
+	 * 
+	 * @since 3.17.0
+	 */
+	triggerKind?: CodeActionTriggerKind;
+
 	/**
 	 * An array of diagnostics known on the client side overlapping the range
 	 * provided to the `textDocument/codeAction` request. They are provided so


### PR DESCRIPTION
Implements the newly finalized API from VS Code for the `CodeActionTriggerKind` in `CodeActionContext`.

Fixes #1244