### PR TITLE
Add textDocument/inlayHints

### DIFF
--- a/_data/specification-3-17-toc.yml
+++ b/_data/specification-3-17-toc.yml
@@ -229,6 +229,8 @@
       anchor: textDocument_linkedEditingRange
     - title: moniker
       anchor: textDocument_moniker
+    - title: inlay hints
+      anchor: textDocument_inlayHints
   - title: Change Log
     anchor: changeLog
     children:

--- a/_specifications/specification-3-17.md
+++ b/_specifications/specification-3-17.md
@@ -8269,11 +8269,6 @@ _Server Capability_:
 
 ```typescript
 export interface InlayHintsOptions extends WorkDoneProgressOptions {
-	/**
-	 * Whether the server supports retrieving inlay hints for a limited range
-	 * within a document.
-	 */
-	range?: boolean;
 }
 ```
 
@@ -8300,9 +8295,6 @@ export interface InlayHintsParams extends WorkDoneProgressParams, PartialResultP
 	/**
 	 * The range the inlay hints are requested for.
 	 * If unset, returns all hints for the document.
-	 * Servers that do not set InlayHintsOptions.range may ignore this.
-	 * 
-	 * TODO: it's more common in LSP to have a separate request - do we need to?
 	 */
 	range?: Range;
 

--- a/_specifications/specification-3-17.md
+++ b/_specifications/specification-3-17.md
@@ -8222,9 +8222,6 @@ Server implementations of this method should ensure that the moniker calculation
 > *Since version 3.17.0*
 
 Inlay hints are short textual annotations that are attached to ranges in the source code.
-
-**TODO**: Is "inlay hints" too presentational a name? The protocol allows other UI (e.g. pop-up when cursor is in the target range).
-
 These typically spell out some inferred information, such as the parameter name when passing a value to a function.
 
 ```typescript

--- a/_specifications/specification-3-17.md
+++ b/_specifications/specification-3-17.md
@@ -8230,7 +8230,7 @@ These typically spell out some inferred information, such as the parameter name 
 ```typescript
 /**
  * Well-known kinds of information conveyed by InlayHints.
- * This is not an exhaustive list, servers may use other categories as needed.
+ * Clients may choose to display hints from some categories but not others.
  */
 export enum InlayHintCategory {
 	/**
@@ -8257,7 +8257,8 @@ Hints in the same class are displayed in similar ways, and the class avoids dupl
 export interface InlayHintClass {
 	/**
 	 * The kind of information this hint conveys.
-	 * May be an InlayHintCategory or any other value. 
+	 * May be an InlayHintCategory or any other value, clients should treat
+	 * unrecognized values as if missing.
 	 */
 	category?: string;
 
@@ -8349,7 +8350,12 @@ export interface InlayHintsParams extends WorkDoneProgressParams, PartialResultP
 	 */
 	range?: Range;
 
-	// TODO: is 'only' useful in practice?
+	/**
+	 * The categories of inlay hints that are interesting to the client.
+	 * The client should filter out hints of other categories, so the server may
+	 * skip computing them.
+	 */
+	only?: string[];
 }
 ```
 

--- a/_specifications/specification-3-17.md
+++ b/_specifications/specification-3-17.md
@@ -8234,12 +8234,12 @@ export enum InlayHintCategory {
 	 * The range is an expression passed as an argument to a function.
 	 * The label is the name of the parameter.
 	 */
-	'parameter',
+	Parameter = 'parameter',
 	/**
 	 * The range is an entity whose type is unknown.
 	 * The label is its inferred type.
 	 */
-	'type'
+	Type = 'type'
 }
 ```
 

--- a/_specifications/specification-3-17.md
+++ b/_specifications/specification-3-17.md
@@ -8227,7 +8227,7 @@ These typically spell out some inferred information, such as the parameter name 
 ```typescript
 /**
  * Well-known kinds of information conveyed by InlayHints.
- * Clients may choose to display hints from some categories but not others.
+ * Clients may choose which categories to display according to user preferences.
  */
 export enum InlayHintCategory {
 	/**

--- a/_specifications/specification-3-17.md
+++ b/_specifications/specification-3-17.md
@@ -8221,7 +8221,7 @@ Server implementations of this method should ensure that the moniker calculation
 
 > *Since version 3.17.0*
 
-Inlay hints are short textual annotations that are attached to ranges in the source code.
+Inlay hints are short textual annotations that are attached to points in the source code.
 These typically spell out some inferred information, such as the parameter name when passing a value to a function.
 
 ```typescript
@@ -8326,10 +8326,9 @@ export interface InlayHint {
 	label: string;
 
 	/**
-	 * The range of text this hint is attached to.
-	 * May affect when the hint is displayed, and the effect of selecting it.
+	 * The position within the code this hint is attached to.
 	 */
-	target: Range;
+	position: Position;
 
 	/**
 	 * The kind of information this hint conveys.

--- a/_specifications/specification-3-17.md
+++ b/_specifications/specification-3-17.md
@@ -8243,41 +8243,6 @@ export enum InlayHintCategory {
 }
 ```
 
-Hints may be grouped into server-defined _classes_.
-Hints in the same class are displayed in similar ways, and the class avoids duplicating this information in each hint.
-
-**TODO**: classes might be useful "subcategories" for users to enable/disable hints. If so, they'd need a description.
-
-**TODO**: are classes actually useful? should we just inline this info into the hints?
-
-```typescript
-export interface InlayHintClass {
-	/**
-	 * The kind of information this hint conveys.
-	 * May be an InlayHintCategory or any other value, clients should treat
-	 * unrecognized values as if missing.
-	 */
-	category?: string;
-
-	/**
-	 * The placement of the label, when displayed inline.
-	 * "start" and "end" mean insertion at the endpoints of the target range.
-	 * Default is "start".
-	 */
-	position?: "start" | "end";
- 
-	/**
-	 * Text to be displayed before the label when displayed inline.
-	 * Typically this is punctuation allowing it to read naturally as code.
-	 */
-	prefix?: string;
-	/**
-	 * Text to be displayed after the label when displayed inline.
-	 */
-	suffix?: string;
-}
-```
-
 The `textDocument/inlayHints` request is sent from the client to the server to retrieve inlay hints for a document.
 
 _Client Capabilities_:
@@ -8304,12 +8269,6 @@ _Server Capability_:
 
 ```typescript
 export interface InlayHintsOptions extends WorkDoneProgressOptions {
-	/**
-	 * Defines the classes of hints the server will provide.
-	 * Individual hints may reference one of these by index.
-	 */
-	hintClasses?: InlayHintClass[],
-
 	/**
 	 * Whether the server supports retrieving inlay hints for a limited range
 	 * within a document.
@@ -8370,7 +8329,7 @@ _Response_:
  */
 export interface InlayHint {
 	/**
-	 * The value to be shown.
+	 * The text to be shown.
 	 */
 	label: string;
 
@@ -8381,16 +8340,11 @@ export interface InlayHint {
 	target: Range;
 
 	/**
-	 * References an InlayHintClass that provides additional properties.
-	 * This is an index into InlayHintsOptions.hintClasses.
+	 * The kind of information this hint conveys.
+	 * May be an InlayHintCategory or any other value, clients should treat
+	 * unrecognized values as if missing.
 	 */
-	hintClass?: uinteger
-
-	/**
-	 * The placement of the label, when displayed inline.
-	 * This overrides the default value set by the class.
-	 */ 
-	position?: Position;
+	category?: string;
 }
 ```
 

--- a/_specifications/specification-3-17.md
+++ b/_specifications/specification-3-17.md
@@ -8396,6 +8396,8 @@ export interface InlayHint {
 
 **TODO**: Do we need a `/refresh` server->client call, like with SemanticTokens and Code Lens?
 
+**TODO**: Likely future evolution: add a `/resolve` call enabling interactions with hints. Should we foreshadow this?
+
 ### <a href="#implementationConsiderations" name="implementationConsiderations" class="anchor">Implementation Considerations</a>
 
 Language servers usually run in a separate process and client communicate with them in an asynchronous fashion. Additionally clients usually allow users to interact with the source code even if request results are pending. We recommend the following implementation pattern to avoid that clients apply outdated response results:


### PR DESCRIPTION
First draft, several points left open, marked as TODO and feedback sought. I do plan to do a VSCode client implementation but wanted to get feedback on design choices first.

Fixes https://github.com/microsoft/language-server-protocol/issues/956, and mostly inspired by rust-analyzer's inlayHints.

This retrieves annotations, it's structurally similar to diagnostics, semantic tokens, outline etc. It's a **pull request rather than push** because that seems to be the preference for recent LSP changes (semantic tokens, pull-diagnostics).

This is a **separate request** rather than combining with `codeLens`. The overlap doesn't seem huge to me and I'm worried about creating a very complicated feature that various editors support different "profiles" of.

The main UI idea is to display the annotations permanently in little "chips" that appear in the source code. But **other presentations are possible**, e.g. a small tooltip-like panel that appears when the cursor is in the target area. The separation of prefix/suffix is mostly to enable alternate presentations.

This **does *not* support hints that replace existing text**, as described in https://github.com/microsoft/vscode/pull/113285#issuecomment-750864435. It IMO adds too much complexity for too little value, but could be revisited later.
 - it's not supported in vscode's inlay hints impl now, and is challenging to implement in editors
 - it essentially requires a different interaction (e.g. a hotkey to enable)
 - servers will need to juggle client capabilities and user preferences in deciding how to expose hints

**Hint Classes**: I suspect the idea of hint classes is either too big or too small. It's meant to express the commonality between e.g. how type-chaining hints in Java should look. But probably either it should grow to something user-visible that can be toggled on/off, or disappear as a premature wire-size optimization.

**Code actions**: this isn't spelled out in the text, but I imagine we could support "code actions on hints" (e.g. spell out inferred type) in a lightweight way by triggering a codeAction request on the target range. This is a small part of the motivation for having the target range.

**Invalidation**: This doesn't support fine-grained invalidation of the kind @Veetaha proposed in #956, IME a coarse-grained server->client request like `workspace/semanticTokens/refresh` is enough when you really need this, despite the very coarse granularity (and you can get a long way without invalidating at all). But interested in practical experience here.

cc @dbaeumer @matklad @SomeoneToIgnore @kjeremy @Veetaha @HighCommander4