### PR TITLE
Fix missing semicolon in specification 3.16 and 3.17

### DIFF
--- a/_specifications/specification-3-16.md
+++ b/_specifications/specification-3-16.md
@@ -1875,7 +1875,7 @@ export interface TextDocumentClientCapabilities {
 	/**
 	 * Capabilities specific to the `textDocument/formatting` request.
 	 */
-	formatting?: DocumentFormattingClientCapabilities
+	formatting?: DocumentFormattingClientCapabilities;
 
 	/**
 	 * Capabilities specific to the `textDocument/rangeFormatting` request.

--- a/_specifications/specification-3-17.md
+++ b/_specifications/specification-3-17.md
@@ -1894,7 +1894,7 @@ export interface TextDocumentClientCapabilities {
 	/**
 	 * Capabilities specific to the `textDocument/formatting` request.
 	 */
-	formatting?: DocumentFormattingClientCapabilities
+	formatting?: DocumentFormattingClientCapabilities;
 
 	/**
 	 * Capabilities specific to the `textDocument/rangeFormatting` request.


### PR DESCRIPTION
Just a small typo fix.