### PR TITLE
Clarify isIncomplete feature behavior.

### DIFF
--- a/_specifications/specification-3-14.md
+++ b/_specifications/specification-3-14.md
@@ -2855,8 +2855,11 @@ _Response_:
  */
 interface CompletionList {
 	/**
-	 * This list it not complete. Further typing should result in recomputing
+	 * This list is not complete. Further typing should result in recomputing
 	 * this list.
+	 *
+	 * Recomputed lists have all their items replaced (not appended) in the
+	 * incomplete completion sessions.
 	 */
 	isIncomplete: boolean;
 

--- a/_specifications/specification-3-15.md
+++ b/_specifications/specification-3-15.md
@@ -3362,8 +3362,11 @@ _Response_:
  */
 export interface CompletionList {
 	/**
-	 * This list it not complete. Further typing should result in recomputing
+	 * This list is not complete. Further typing should result in recomputing
 	 * this list.
+	 *
+	 * Recomputed lists have all their items replaced (not appended) in the
+	 * incomplete completion sessions.
 	 */
 	isIncomplete: boolean;
 

--- a/_specifications/specification-3-16.md
+++ b/_specifications/specification-3-16.md
@@ -4480,6 +4480,9 @@ export interface CompletionList {
 	/**
 	 * This list is not complete. Further typing should result in recomputing
 	 * this list.
+	 *
+	 * Recomputed lists have all their items replaced (not appended) in the
+	 * incomplete completion sessions.
 	 */
 	isIncomplete: boolean;
 

--- a/_specifications/specification-3-17.md
+++ b/_specifications/specification-3-17.md
@@ -4551,6 +4551,9 @@ export interface CompletionList {
 	/**
 	 * This list is not complete. Further typing should result in recomputing
 	 * this list.
+	 *
+	 * Recomputed lists have all their items replaced (not appended) in the
+	 * incomplete completion sessions.
 	 */
 	isIncomplete: boolean;
 


### PR DESCRIPTION
- When playing around with isIncomplete it was unclear from the spec perspective on the appropriate handling of isIncomplete. Clarifying that isIncomplete should represent "replaced" items and not "appended" items makes it clear how a language server should handle the feature.
- Ported the wording to all previous specs + fixed some typos.