### PR TITLE
Fix: missing empty lines between html end tags and start of code blocks

### DIFF
--- a/_specifications/specification-3-17.md
+++ b/_specifications/specification-3-17.md
@@ -70,6 +70,7 @@ The following TypeScript definitions describe the base [JSON-RPC protocol](http:
 The protocol use the following definitions for integers, unsigned integers and decimal numbers:
 
 <div class="anchorHolder"><a href="#integer" name="integer" class="linkableAnchor"></a></div>
+
 ```typescript
 /**
  * Defines an integer number in the range of -2^31 to 2^31 - 1.
@@ -78,6 +79,7 @@ export type integer = number;
 ```
 
 <div class="anchorHolder"><a href="#uinteger" name="uinteger" class="linkableAnchor"></a></div>
+
 ```typescript
 /**
  * Defines an unsigned integer number in the range of 0 to 2^31 - 1.
@@ -86,6 +88,7 @@ export type uinteger = number;
 ```
 
 <div class="anchorHolder"><a href="#decimal" name="decimal" class="linkableAnchor"></a></div>
+
 ```typescript
 /**
  * Defines a decimal number. Since decimal numbers are very
@@ -102,6 +105,7 @@ export type decimal = number;
 A general message as defined by JSON-RPC. The language server protocol always uses "2.0" as the `jsonrpc` version.
 
 <div class="anchorHolder"><a href="#message" name="message" class="linkableAnchor"></a></div>
+
 ```typescript
 interface Message {
 	jsonrpc: string;
@@ -156,6 +160,7 @@ interface ResponseMessage extends Message {
 ```
 
 <div class="anchorHolder"><a href="#responseError" name="responseError" class="linkableAnchor"></a></div>
+
 ```typescript
 interface ResponseError {
 	/**
@@ -177,6 +182,7 @@ interface ResponseError {
 ```
 
 <div class="anchorHolder"><a href="#errorCodes" name="errorCodes" class="linkableAnchor"></a></div>
+
 ```typescript
 export namespace ErrorCodes {
 	// Defined by JSON RPC
@@ -363,6 +369,7 @@ We also maintain a node module to parse a string into `scheme`, `authority`, `pa
 Many of the interfaces contain fields that correspond to the URI of a document. For clarity, the type of such a field is declared as a `DocumentUri`. Over the wire, it will still be transferred as a string, but this guarantees that the contents of that string can be parsed as a valid URI.
 
 <div class="anchorHolder"><a href="#documentUri" name="documentUri" class="linkableAnchor"></a></div>
+
 ```typescript
 type DocumentUri = string;
 ```
@@ -591,6 +598,7 @@ export interface Diagnostic {
 The protocol currently supports the following diagnostic severities and tags:
 
 <div class="anchorHolder"><a href="#diagnosticSeverity" name="diagnosticSeverity" class="linkableAnchor"></a></div>
+
 ```typescript
 export namespace DiagnosticSeverity {
 	/**
@@ -615,6 +623,7 @@ export type DiagnosticSeverity = 1 | 2 | 3 | 4;
 ```
 
 <div class="anchorHolder"><a href="#diagnosticTag" name="diagnosticTag" class="linkableAnchor"></a></div>
+
 ```typescript
 /**
  * The diagnostic tags.
@@ -643,6 +652,7 @@ export type DiagnosticTag = 1 | 2;
 `DiagnosticRelatedInformation` is defined as follows:
 
 <div class="anchorHolder"><a href="#diagnosticRelatedInformation" name="diagnosticRelatedInformation" class="linkableAnchor"></a></div>
+
 ```typescript
 /**
  * Represents a related message and source code location for a diagnostic.
@@ -665,6 +675,7 @@ export interface DiagnosticRelatedInformation {
 `CodeDescription` is defined as follows:
 
 <div class="anchorHolder"><a href="#codeDescription" name="codeDescription" class="linkableAnchor"></a></div>
+
 ```typescript
 /**
  * Structure to capture a description for an error code.
@@ -726,6 +737,7 @@ interface TextEdit {
 Since 3.16.0 there is also the concept of an annotated text edit which supports to add an annotation to a text edit. The annotation can add information describing the change to the text edit.
 
 <div class="anchorHolder"><a href="#changeAnnotation" name="changeAnnotation" class="linkableAnchor"></a></div>
+
 ```typescript
 /**
  * Additional information that describes document changes.
@@ -756,6 +768,7 @@ export interface ChangeAnnotation {
 Usually clients provide options to group the changes along the annotations they are associated with. To support this in the protocol an edit or resource operation refers to a change annotation using an identifier and not the change annotation literal directly. This allows servers to use the identical annotation across multiple edits or resource operations which then allows clients to group the operations under that change annotation. The actual change annotations together with their identifers are managed by the workspace edit via the new property `changeAnnotations`.
 
 <div class="anchorHolder"><a href="#changeAnnotationIdentifier" name="changeAnnotationIdentifier" class="linkableAnchor"></a></div>
+
 ```typescript
 /**
  * An identifier referring to a change annotation managed by a workspace
@@ -767,6 +780,7 @@ export type ChangeAnnotationIdentifier = string;
 ```
 
 <div class="anchorHolder"><a href="#annotatedTextEdit" name="annotatedTextEdit" class="linkableAnchor"></a></div>
+
 ```typescript
 /**
  * A special text edit with an additional change annotation.
@@ -817,6 +831,7 @@ export interface TextDocumentEdit {
 File resource changes allow servers to create, rename and delete files and folders via the client. Note that the names talk about files but the operations are supposed to work on files and folders. This is in line with other naming in the Language Server Protocol (see file watchers which can watch files and folders). The corresponding change literals look as follows:
 
 <div class="anchorHolder"><a href="#createFileOptions" name="createFileOptions" class="linkableAnchor"></a></div>
+
 ```typescript
 /**
  * Options to create a file.
@@ -835,6 +850,7 @@ export interface CreateFileOptions {
 ```
 
 <div class="anchorHolder"><a href="#createFile" name="createFile" class="linkableAnchor"></a></div>
+
 ```typescript
 /**
  * Create file operation
@@ -865,6 +881,7 @@ export interface CreateFile {
 ```
 
 <div class="anchorHolder"><a href="#renameFileOptions" name="renameFileOptions" class="linkableAnchor"></a></div>
+
 ```typescript
 /**
  * Rename file options
@@ -883,6 +900,7 @@ export interface RenameFileOptions {
 ```
 
 <div class="anchorHolder"><a href="#renameFile" name="renameFile" class="linkableAnchor"></a></div>
+
 ```typescript
 /**
  * Rename file operation
@@ -918,6 +936,7 @@ export interface RenameFile {
 ```
 
 <div class="anchorHolder"><a href="#deleteFileOptions" name="deleteFileOptions" class="linkableAnchor"></a></div>
+
 ```typescript
 /**
  * Delete file options
@@ -936,6 +955,7 @@ export interface DeleteFileOptions {
 ```
 
 <div class="anchorHolder"><a href="#deleteFile" name="deleteFile" class="linkableAnchor"></a></div>
+
 ```typescript
 /**
  * Delete file operation
@@ -1075,6 +1095,7 @@ export interface WorkspaceEditClientCapabilities {
 ```
 
 <div class="anchorHolder"><a href="#resourceOperationKind" name="resourceOperationKind" class="linkableAnchor"></a></div>
+
 ```typescript
 /**
  * The kind of resource operations supported by the client.
@@ -1101,6 +1122,7 @@ export namespace ResourceOperationKind {
 ```
 
 <div class="anchorHolder"><a href="#failureHandlingKind" name="failureHandlingKind" class="linkableAnchor"></a></div>
+
 ```typescript
 export type FailureHandlingKind = 'abort' | 'transactional' | 'undo'
 	| 'textOnlyTransactional';
@@ -1258,6 +1280,7 @@ interface VersionedTextDocumentIdentifier extends TextDocumentIdentifier {
 An identifier which optionally denotes a specific version of a text document. This information usually flows from the server to the client.
 
 <div class="anchorHolder"><a href="#optionalVersionedTextDocumentIdentifier" name="optionalVersionedTextDocumentIdentifier" class="linkableAnchor"></a></div>
+
 ```typescript
 interface OptionalVersionedTextDocumentIdentifier extends TextDocumentIdentifier {
 	/**
@@ -1337,6 +1360,7 @@ export interface DocumentFilter {
 A document selector is the combination of one or more document filters.
 
 <div class="anchorHolder"><a href="#documentSelector" name="documentSelector" class="linkableAnchor"></a></div>
+
 ```typescript
 export type DocumentSelector = DocumentFilter[];
 ```
@@ -1402,6 +1426,7 @@ export type MarkupKind = 'plaintext' | 'markdown';
 ```
 
 <div class="anchorHolder"><a href="#markupContentDefinition" name="markupContentInnerDefinition" class="linkableAnchor"></a></div>
+
 ```typescript
 /**
  * A `MarkupContent` literal represents a string value which content is
@@ -1610,6 +1635,7 @@ The corresponding type definition for the parameter property looks like this:
 
 
 <div class="anchorHolder"><a href="#workDoneProgressParams" name="workDoneProgressParams" class="linkableAnchor"></a></div>
+
 ```typescript
 export interface WorkDoneProgressParams {
 	/**
@@ -1651,6 +1677,7 @@ To avoid that clients set up a progress monitor user interface before sending a 
 The corresponding type definition for the server capability looks like this:
 
 <div class="anchorHolder"><a href="#workDoneProgressOptions" name="workDoneProgressOptions" class="linkableAnchor"></a></div>
+
 ```typescript
 export interface WorkDoneProgressOptions {
 	workDoneProgress?: boolean;
@@ -1769,6 +1796,7 @@ _Request_:
 * params: `InitializeParams` defined as follows:
 
 <div class="anchorHolder"><a href="#initializeParams" name="initializeParams" class="linkableAnchor"></a></div>
+
 ```typescript
 interface InitializeParams extends WorkDoneProgressParams {
 	/**
@@ -1859,6 +1887,7 @@ Where `ClientCapabilities` and `TextDocumentClientCapabilities` are defined as f
 `TextDocumentClientCapabilities` define capabilities the editor / tool provides on text documents.
 
 <div class="anchorHolder"><a href="#textDocumentClientCapabilities" name="textDocumentClientCapabilities" class="linkableAnchor"></a></div>
+
 ```typescript
 /**
  * Text document specific client capabilities.
@@ -2021,6 +2050,7 @@ export interface TextDocumentClientCapabilities {
 Client capabilities got introduced with version 3.0 of the protocol. They therefore only describe capabilities that got introduced in 3.x or later. Capabilities that existed in the 2.x version of the protocol are still mandatory for clients. Clients cannot opt out of providing them. So even if a client omits the `ClientCapabilities.textDocument.synchronization` it is still required that the client provides text document synchronization (e.g. open, changed and close notifications).
 
 <div class="anchorHolder"><a href="#clientCapabilities" name="clientCapabilities" class="linkableAnchor"></a></div>
+
 ```typescript
 interface ClientCapabilities {
 	/**
@@ -2222,6 +2252,7 @@ _Response_:
 * result: `InitializeResult` defined as follows:
 
 <div class="anchorHolder"><a href="#initializeResult" name="initializeResult" class="linkableAnchor"></a></div>
+
 ```typescript
 interface InitializeResult {
 	/**
@@ -2250,6 +2281,7 @@ interface InitializeResult {
 * error.code:
 
 <div class="anchorHolder"><a href="#initializeError" name="initializeError" class="linkableAnchor"></a></div>
+
 ```typescript
 /**
  * Known error codes for an `InitializeError`;
@@ -2283,6 +2315,7 @@ interface InitializeError {
 The server can signal the following capabilities:
 
 <div class="anchorHolder"><a href="#serverCapabilities" name="serverCapabilities" class="linkableAnchor"></a></div>
+
 ```typescript
 interface ServerCapabilities {
 	/**


### PR DESCRIPTION
See: https://spec.commonmark.org/0.29/#example-131