### PR TITLE
SDKs: Added Langium, moved Xtext

### DIFF
--- a/_implementors/sdks.md
+++ b/_implementors/sdks.md
@@ -20,8 +20,9 @@ index: 3
 | Haskell | [Alan Zimmerman](https://github.com/alanz) | [Haskell-LSP](https://github.com/alanz/haskell-lsp)|
 | Haskell | [Luke Lau](https://github.com/Bubba) | [lsp-test](https://github.com/Bubba/lsp-test)|
 | Haxe | @nadako | [language-server-protocol-haxe](https://github.com/vshaxe/language-server-protocol-haxe)|
-| Java | Eclipse, TypeFox |  [Eclipse LSP4J](https://github.com/eclipse/lsp4j) |
+| Java | [Eclipse LSP4J committers](https://projects.eclipse.org/projects/technology.lsp4j/who) |  [lsp4j](https://github.com/eclipse/lsp4j) |
 | Java | [lxtk.org](https://github.com/lxtk-org) | [LXTK](https://github.com/lxtk-org/lxtk) |
+| Java | [Eclipse Xtext committers](https://projects.eclipse.org/projects/modeling.tmf.xtext/who) |  [xtext-core](https://github.com/eclipse/xtext-core) |
 | node.js | MS | [vscode-languageserver-node](https://github.com/Microsoft/vscode-languageserver-node)  |
 | Objective-C | [Christopher Atlan](https://twitter.com/catlan) | [LSPKit](https://github.com/catlan/LSPKit)|
 | PHP | [Felix Becker](https://github.com/felixfbecker) | [php-language-server](https://github.com/felixfbecker/php-language-server)|
@@ -31,4 +32,5 @@ index: 3
 | Rust | Bruno Medeiros and Markus Westerlind | [lsp-types](https://github.com/gluon-lang/lsp-types)
 | Rust | [Eyal Kalderon](https://github.com/ebkalderon) | [tower-lsp](https://github.com/ebkalderon/tower-lsp)
 | Swift | [Chime](https://twitter.com/chimehq) | [SwiftLSPClient](https://github.com/chimehq/SwiftLSPClient)|
+| TypeScript | [TypeFox](https://www.typefox.io/) | [langium](https://github.com/langium/langium)|
 {: .table .table-bordered .table-responsive}

--- a/_implementors/servers.md
+++ b/_implementors/servers.md
@@ -159,7 +159,6 @@ index: 1
 | WXML| [Qiming Zhao](https://github.com/chemzqm)| [wxml-languageserver](https://github.com/chemzqm/wxml-languageserver) | TypeScript |
 | XML | IBM | [XML Language Server](https://github.com/microclimate-devops/xml-language-server) | Java |
 | XML | [Red Hat Developers](https://github.com/redhat-developer) and [Angelo ZERR](https://github.com/angelozerr/) | [XML Language Server (LemMinX)](https://github.com/eclipse/lemminx) | Java |
-| [Xtext language framework](https://www.eclipse.org/Xtext/) | Eclipse | [Eclipse Xtext](https://github.com/eclipse/xtext-core/blob/master/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/LanguageServerImpl.java)| Java |
 | YAML (with JSON schemas)| [Adam Voss](https://github.com/adamvoss) | [vscode-yaml-languageservice](https://github.com/adamvoss/vscode-yaml-languageservice) | TypeScript |
 | YAML| [Red Hat Developers](https://github.com/redhat-developer) | [yaml-language-server](https://github.com/redhat-developer/yaml-language-server) | TypeScript |
 | [YANG](https://tools.ietf.org/html/rfc7950)| [Yang tools](https://github.com/yang-tools) | [yang-lsp](https://github.com/yang-tools/yang-lsp) |  XTend |


### PR DESCRIPTION
 - Added [Langium](https://github.com/langium/langium), a new language server SDK written in TypeScript
 - Moved Xtext from _Language Servers_ to _SDKs_ and added link to project committers
 - Added link to LSP4J project committers