### PR TITLE
Add source.fixAll constant

### DIFF
--- a/_specifications/specification-3-17.md
+++ b/_specifications/specification-3-17.md
@@ -6684,6 +6684,16 @@ export namespace CodeActionKind {
 
 	/**
 	 * Base kind for an organize imports source action:
+	 * `source.fixAll`.
+	 *
+	 * Fix all actions automatically fix errors that have a clear fix that
+	 * do not require user input. They should not suppress errors or perform
+	 * unsafe fixes such as generating new types or classes.
+	 */
+	export const SourceFixAll: CodeActionKind = 'source.fixAll';
+
+	/**
+	 * Base kind for an organize imports source action:
 	 * `source.organizeImports`.
 	 */
 	export const SourceOrganizeImports: CodeActionKind =


### PR DESCRIPTION
@dbaeumer I don't know if this is reasonable, but VS Code has a constant for it and it seems like it would be useful for the same reason as having `source.organizeImports` here - so clients can provide better UI beyond just the Source Actions list for invoking this kind of (common) operation.