### PR TITLE
Update comment for jsonrpcReservedErrorRangeEnd

### DIFF
--- a/_specifications/specification-3-16.md
+++ b/_specifications/specification-3-16.md
@@ -202,7 +202,7 @@ export namespace ErrorCodes {
 	export const UnknownErrorCode: integer = -32001;
 
 	/**
-	 * This is the start range of JSON RPC reserved error codes.
+	 * This is the end range of JSON RPC reserved error codes.
 	 * It doesn't denote a real error code.
 	 *
 	 * @since 3.16.0


### PR DESCRIPTION
The comment states that it is the start of the range, but the variable name states it is the end. The variable name seems to be correct, so update the comment.