### PR TITLE
Add support for textDocument/inlineValues

### DIFF
--- a/_specifications/specification-3-17.md
+++ b/_specifications/specification-3-17.md
@@ -2047,6 +2047,8 @@ export interface TextDocumentClientCapabilities {
 
 	/**
 	 * Capabilities specific to the `textDocument/inlineValues` request.
+	 *
+	 * @since 3.17.0
 	 */
 	inlineValues?: InlineValuesClientCapabilities;
 }
@@ -2127,6 +2129,14 @@ interface ClientCapabilities {
 		 * @since 3.16.0
 		 */
 		codeLens?: CodeLensWorkspaceClientCapabilities;
+
+		/**
+		 * Capabilities specific to the inline values requests scoped to the
+		 * workspace.
+		 *
+		 * @since 3.17.0
+		 */
+		inlineValues?: InlineValuesWorkspaceClientCapabilities;
 
 		/**
 		 * The client has support for file requests/notifications.
@@ -8901,6 +8911,10 @@ export interface Moniker {
 }
 ```
 
+##### Notes
+
+Server implementations of this method should ensure that the moniker calculation matches to those used in the corresponding LSIF implementation to ensure symbols can be associated correctly across IDE sessions and LSIF indexes.
+
 #### <a href="#textDocument_inlineValues" name="textDocument_inlineValues" class="anchor">Inline Values Request (:leftwards_arrow_with_hook:)</a>
 
 > *Since version 3.17.0*
@@ -9054,9 +9068,43 @@ export class InlineValueEvaluatableExpression {
 ```
 * error: code and message set in case an exception happens during the inline values request.
 
-##### Notes
+#### <a href="#inlineValues_refresh" name="inlineValues_refresh" class="anchor">Inline Values Refresh Request (:arrow_right_hook:)</a>
 
-Server implementations of this method should ensure that the moniker calculation matches to those used in the corresponding LSIF implementation to ensure symbols can be associated correctly across IDE sessions and LSIF indexes.
+> *Since version 3.17.0*
+
+The `workspace/inlineValues/refresh` request is sent from the server to the client. Servers can use it to ask clients to refresh the inline values currently shown in editors. As a result the client should ask the server to recompute the inline values for these editors. This is useful if a server detects a change which requires a re-calculation of all inline values. Note that the client still has the freedom to delay the re-calculation of the inline values if for example an editor is currently not visible.
+
+_Client Capability_:
+
+* property name (optional): `workspace.inlineValues`
+* property type: `InlineValuesWorkspaceClientCapabilities` defined as follows:
+
+<div class="anchorHolder"><a href="#inlineValuesWorkspaceClientCapabilities" name="inlineValuesWorkspaceClientCapabilities" class="linkableAnchor"></a></div>
+
+```typescript
+export interface InlineValuesWorkspaceClientCapabilities {
+	/**
+	 * Whether the client implementation supports a refresh request sent from the
+	 * server to the client.
+	 *
+	 * Note that this event is global and will force the client to refresh all
+	 * inline values currently shown. It should be used with absolute care and is
+	 * useful for situation where a server for example detect a project wide
+	 * change that requires such a calculation.
+	 */
+	refreshSupport?: boolean;
+}
+```
+
+_Request_:
+
+* method: `workspace/inlineValues/refresh`
+* params: none
+
+_Response_:
+
+* result: void
+* error: code and message set in case an exception happens during the 'workspace/inlineValues/refresh' request
 
 ### <a href="#implementationConsiderations" name="implementationConsiderations" class="anchor">Implementation Considerations</a>
 

--- a/_specifications/specification-3-17.md
+++ b/_specifications/specification-3-17.md
@@ -2131,14 +2131,6 @@ interface ClientCapabilities {
 		codeLens?: CodeLensWorkspaceClientCapabilities;
 
 		/**
-		 * Capabilities specific to the inline values requests scoped to the
-		 * workspace.
-		 *
-		 * @since 3.17.0
-		 */
-		inlineValues?: InlineValuesWorkspaceClientCapabilities;
-
-		/**
 		 * The client has support for file requests/notifications.
 		 *
 		 * @since 3.16.0
@@ -9067,44 +9059,6 @@ export class InlineValueEvaluatableExpression {
 }
 ```
 * error: code and message set in case an exception happens during the inline values request.
-
-#### <a href="#inlineValues_refresh" name="inlineValues_refresh" class="anchor">Inline Values Refresh Request (:arrow_right_hook:)</a>
-
-> *Since version 3.17.0*
-
-The `workspace/inlineValues/refresh` request is sent from the server to the client. Servers can use it to ask clients to refresh the inline values currently shown in editors. As a result the client should ask the server to recompute the inline values for these editors. This is useful if a server detects a change which requires a re-calculation of all inline values. Note that the client still has the freedom to delay the re-calculation of the inline values if for example an editor is currently not visible.
-
-_Client Capability_:
-
-* property name (optional): `workspace.inlineValues`
-* property type: `InlineValuesWorkspaceClientCapabilities` defined as follows:
-
-<div class="anchorHolder"><a href="#inlineValuesWorkspaceClientCapabilities" name="inlineValuesWorkspaceClientCapabilities" class="linkableAnchor"></a></div>
-
-```typescript
-export interface InlineValuesWorkspaceClientCapabilities {
-	/**
-	 * Whether the client implementation supports a refresh request sent from the
-	 * server to the client.
-	 *
-	 * Note that this event is global and will force the client to refresh all
-	 * inline values currently shown. It should be used with absolute care and is
-	 * useful for situation where a server for example detect a project wide
-	 * change that requires such a calculation.
-	 */
-	refreshSupport?: boolean;
-}
-```
-
-_Request_:
-
-* method: `workspace/inlineValues/refresh`
-* params: none
-
-_Response_:
-
-* result: void
-* error: code and message set in case an exception happens during the 'workspace/inlineValues/refresh' request
 
 ### <a href="#implementationConsiderations" name="implementationConsiderations" class="anchor">Implementation Considerations</a>
 

--- a/_specifications/specification-3-17.md
+++ b/_specifications/specification-3-17.md
@@ -2044,6 +2044,11 @@ export interface TextDocumentClientCapabilities {
 	 * @since 3.16.0
 	 */
 	moniker?: MonikerClientCapabilities;
+
+	/**
+	 * Capabilities specific to the `textDocument/inlineValues` request.
+	 */
+	inlineValues?: InlineValuesClientCapabilities;
 }
 ```
 
@@ -2485,6 +2490,11 @@ interface ServerCapabilities {
 	 * @since 3.16.0
 	 */
 	monikerProvider?: boolean | MonikerOptions | MonikerRegistrationOptions;
+
+	/**
+	 * The server provides inline values.
+	 */
+	inlineValuesProvider?: InlineValuesOptions;
 
 	/**
 	 * The server provides workspace symbol support.
@@ -8891,6 +8901,159 @@ export interface Moniker {
 }
 ```
 
+#### <a href="#textDocument_inlineValues" name="textDocument_inlineValues" class="anchor">Inline Values Request (:leftwards_arrow_with_hook:)</a>
+
+> *Since version 3.17.0*
+
+The inline values request is sent from the client to the server to compute inline values for a given text document that may be rendered in the editor at the end of lines.
+
+_Client Capability_:
+* property name (optional): `textDocument.inlineValues`
+* property type: `InlineValuesClientCapabilities` defined as follows:
+
+<div class="anchorHolder"><a href="#inlineValuesClientCapabilities" name="inlineValuesClientCapabilities" class="linkableAnchor"></a></div>
+
+```typescript
+export interface InlineValuesClientCapabilities {
+	/**
+	 * Whether inline values supports dynamic registration.
+	 */
+	dynamicRegistration?: boolean;
+}
+```
+
+_Server Capability_:
+* property name (optional): `inlineValuesProvider`
+* property type: `InlineValuesOptions` defined as follows:
+
+<div class="anchorHolder"><a href="#inlineValuesOptions" name="inlineValuesOptions" class="linkableAnchor"></a></div>
+
+```typescript
+export interface InlineValuesOptions extends WorkDoneProgressOptions {
+}
+```
+
+_Registration Options_: `InlineValuesRegistrationOptions` defined as follows:
+
+<div class="anchorHolder"><a href="#inlineValuesRegistrationOptions" name="inlineValuesRegistrationOptions" class="linkableAnchor"></a></div>
+
+```typescript
+export interface InlineValuesRegistrationOptions extends
+	TextDocumentRegistrationOptions, InlineValuesOptions {
+}
+```
+
+_Request_:
+* method: `textDocument/inlineValues`
+* params: `InlineValuesParams` defined as follows:
+
+<div class="anchorHolder"><a href="#inlineValuesParams" name="inlineValuesParams" class="linkableAnchor"></a></div>
+
+```typescript
+interface InlineValuesParams extends WorkDoneProgressParams {
+	/**
+	 * The document to request inline values for.
+	 */
+	readonly textDocument: TextDocumentIdentifier;
+
+	/**
+	 * The visible document range for which inline values should be computed.
+	 */
+	readonly viewPort: Range;
+
+	/**
+	 * Additional information about the context in which inline values were
+	 * requested.
+	 */
+	readonly context: InlineValuesContext;
+}
+```
+
+<div class="anchorHolder"><a href="#inlineValuesContext" name="inlineValuesContext" class="linkableAnchor"></a></div>
+
+```typescript
+interface InlineValuesContext {
+	/**
+	 * The document range where execution has stopped.
+	 * Typically the end position of the range denotes the line where the inline values are shown.
+	 */
+	readonly stoppedLocation: Range;
+}
+```
+
+_Response_:
+* result: `InlineValue[]` \| `null` defined as follows:
+
+<div class="anchorHolder"><a href="#inlineValue" name="inlineValue" class="linkableAnchor"></a></div>
+
+```typescript
+/**
+ * Inline value information can be provided by different means:
+ * - directly as a text value (class InlineValueText).
+ * - as a name to use for a variable lookup (class InlineValueVariableLookup)
+ * - as an evaluatable expression (class InlineValueEvaluatableExpression)
+ * The InlineValue types combines all inline value types into one type.
+ */
+export type InlineValue = InlineValueText | InlineValueVariableLookup | InlineValueEvaluatableExpression;
+
+/**
+ * Provide inline value as text.
+ */
+export class InlineValueText {
+	/**
+	 * The document range for which the inline value applies.
+	 */
+	readonly range: Range;
+
+	/**
+	 * The text of the inline value.
+	 */
+	readonly text: string;
+}
+
+/**
+ * Provide inline value through a variable lookup.
+ * If only a range is specified, the variable name will be extracted from the underlying document.
+ * An optional variable name can be used to override the extracted name.
+ */
+export class InlineValueVariableLookup {
+	/**
+	 * The document range for which the inline value applies.
+	 * The range is used to extract the variable name from the underlying document.
+	 */
+	readonly range: Range;
+
+	/**
+	 * If specified the name of the variable to look up.
+	 */
+	readonly variableName?: string;
+
+	/**
+	 * How to perform the lookup.
+	 */
+	readonly caseSensitiveLookup: boolean;
+}
+
+/**
+ * Provide an inline value through an expression evaluation.
+ * If only a range is specified, the expression will be extracted from the underlying document.
+ * An optional expression can be used to override the extracted expression.
+ */
+export class InlineValueEvaluatableExpression {
+	/**
+	 * The document range for which the inline value applies.
+	 * The range is used to extract the evaluatable expression from the underlying document.
+	 */
+	readonly range: Range;
+
+	/**
+	 * If specified the expression overrides the extracted expression.
+	 */
+	readonly expression?: string;
+}
+```
+* error: code and message set in case an exception happens during the inline values request.
+
 ##### Notes
 
 Server implementations of this method should ensure that the moniker calculation matches to those used in the corresponding LSIF implementation to ensure symbols can be associated correctly across IDE sessions and LSIF indexes.
@@ -8918,6 +9081,7 @@ Servers usually support different communication channels (e.g. stdio, pipes, ...
 #### <a href="#version_3_17_0" name="version_3_17_0" class="anchor">3.17.0 (xx/xx/xxxx)</a>
 
 * Add support for a completion item label details.
+* Add support for `textDocument/inlineValues` request.
 
 #### <a href="#version_3_16_0" name="version_3_16_0" class="anchor">3.16.0 (12/14/2020)</a>
 

--- a/_specifications/specification-3-17.md
+++ b/_specifications/specification-3-17.md
@@ -2054,7 +2054,7 @@ export interface TextDocumentClientCapabilities {
 	/**
 	 * Capabilities specific to the `textDocument/inlineValues` request.
 	 *
-	 * @since 3.17.0
+	 * @since 3.17.0 - proposed state
 	 */
 	inlineValues?: InlineValuesClientCapabilities;
 }
@@ -2501,6 +2501,8 @@ interface ServerCapabilities {
 
 	/**
 	 * The server provides inline values.
+	 *
+	 * @since 3.17.0 - proposed state
 	 */
 	inlineValuesProvider?: InlineValuesOptions;
 
@@ -8926,6 +8928,9 @@ _Client Capability_:
 <div class="anchorHolder"><a href="#inlineValuesClientCapabilities" name="inlineValuesClientCapabilities" class="linkableAnchor"></a></div>
 
 ```typescript
+/**
+ * Client capabilities specific to inline values.
+ */
 export interface InlineValuesClientCapabilities {
 	/**
 	 * Whether inline values supports dynamic registration.
@@ -9091,7 +9096,7 @@ To support the case that the editor starting a server crashes an editor should a
 #### <a href="#version_3_17_0" name="version_3_17_0" class="anchor">3.17.0 (xx/xx/xxxx)</a>
 
 * Add support for a completion item label details.
-* Add support for `textDocument/inlineValues` request.
+* Add support for `textDocument/inlineValues` request (proposed).
 
 #### <a href="#version_3_16_0" name="version_3_16_0" class="anchor">3.16.0 (12/14/2020)</a>
 


### PR DESCRIPTION
Based on the fact that VS Code added it to `vscode.languages` and not DAP, my understanding is that this is intended to be provided by a language server (which already has access to parsed ASTs).

This is intended to mirror the equivalent VS Code feature:

https://github.com/microsoft/vscode/blob/c980ea2307905fd1efeee38915bf1e5ccdff1754/src/vs/vscode.d.ts#L2677-L2852

The only deliberate difference is removal of the DAP frame ID since it doesn't seem useful to provide to a language server (although if I've misunderstood that, it's easy to add back in).

I did not include a request to go the other way (like `codeLens/refresh`) because my assumption is that the client would re-request this when the content changes (and values would not change if the file does not), however if that's not true and we should add a server-to-client `inlineValues/refresh` request, let me know and I'll add.

@dbaeumer 