### PR TITLE
http://tools.ietf.org/html/rfc3986 is no longer a valid URL

### DIFF
--- a/_specifications/specification-3-16.md
+++ b/_specifications/specification-3-16.md
@@ -314,7 +314,7 @@ The protocol currently assumes that one server serves one tool. There is current
 
 #### <a href="#uri" name="uri" class="anchor"> URI </a>
 
-URI's are transferred as strings. The URI's format is defined in [http://tools.ietf.org/html/rfc3986](http://tools.ietf.org/html/rfc3986)
+URI's are transferred as strings.
 
 ```
   foo://example.com:8042/over/there?name=ferret#nose


### PR DESCRIPTION
tools.ietf.org seems to have been sold to someone else since 2006. 2006!!!