### PR TITLE
Sort list of supporting tools alphabetically

### DIFF
--- a/_implementors/tools.md
+++ b/_implementors/tools.md
@@ -10,41 +10,41 @@ index: 2
 
 | Editor/IDE | Maintainer | Repository |
 |------|--------|----------|
-| [Visual Studio Code](https://code.visualstudio.com) | Microsoft | [vscode](https://github.com/Microsoft/vscode/)  |
+| [Acme](https://en.wikipedia.org/wiki/Acme_(text_editor)) | [Fazlul Shahriar](https://github.com/fhs) | [acme-lsp](https://github.com/fhs/acme-lsp) |
+| [Aginity Pro](https://www.aginity.com/products/aginity-pro/) | [Aginity](https://www.aginity.com) | |
+| [Aginity Team](https://www.aginity.com/products/aginity-team/) | [Aginity](https://www.aginity.com) | |
+| [Atom](https://atom.io/) | [GitHub](https://github.com/) | [atom-languageclient](https://www.npmjs.com/package/atom-languageclient) |
+| [BBEdit](https://www.barebones.com/products/bbedit) | [Bare Bones Software, Inc.](https://www.barebones.com/) | Proprietary |
+| [Brackets](http://brackets.io) | [Adobe](https://github.com/adobe) | [brackets](https://github.com/adobe/brackets) |
+| [Cloud Studio](https://studio.dev.tencent.com/) | CODING |  |
+| [CodeLite](https://codelite.org/) | [Eran Ifrah](https://github.com/eranif) | https://github.com/eranif/codelite |
 | [Eclipse Che](https://www.eclipse.org/che/) | Eclipse,Codenvy/TypeFox | [Che](https://github.com/eclipse/che/issues/1287) |
 | Eclipse IDE | Eclipse,Red Hat | [Eclipse community](https://projects.eclipse.org/projects/technology.lsp4e/who), [Eclipse LSP4E](https://projects.eclipse.org/projects/technology.lsp4e) |
-| emacs | [Vibhav Pant](https://github.com/vibhavp) | [emacs language server client](https://github.com/emacs-lsp/lsp-mode/) |
-| GNU Emacs | [João Távora](https://github.com/joaotavora) | [Eglot](https://github.com/joaotavora/eglot) |
+| Emacs | [Vibhav Pant](https://github.com/vibhavp) | [emacs language server client](https://github.com/emacs-lsp/lsp-mode/) |
+| Emacs | [João Távora](https://github.com/joaotavora) | [Eglot](https://github.com/joaotavora/eglot) |
 | [GNOME Builder](https://wiki.gnome.org/Apps/Builder) | [gnome.org](https://wiki.gnome.org/Apps/Builder/) | [language server client](https://git.gnome.org/browse/gnome-builder/tree/src/libide/lsp) |
-| [MS Monaco Editor](https://github.com/Microsoft/monaco-editor) | [TypeFox](https://github.com/TypeFox) | [monaco-languageclient](https://www.npmjs.com/package/monaco-languageclient) |
+| [JCIDE](https://www.javacardos.com/tools) | [Javacardos](https://www.javacardos.com) | [JCIDE](https://www.javacardos.com/javacardforum/viewtopic.php?f=5&t=2108&p=6175#p6175) |
+| [JupyterLab](https://github.com/jupyterlab/jupyterlab) | [krassowski](https://github.com/krassowski) | [jupyterlab-lsp](https://github.com/krassowski/jupyterlab-lsp) |
+| [Kakoune](http://kakoune.org/) | [ul](https://github.com/ul) | [kak-lsp](https://github.com/ul/kak-lsp) |
+| [Kate](https://kate-editor.org) | [Kate Team](https://kate-editor.org) | [kate](https://invent.kde.org/kde/kate) |
 | [Moonshine IDE](https://moonshine-ide.com) | [Prominic.NET](https://github.com/prominic) | [Moonshine-IDE](https://github.com/prominic/Moonshine-IDE) |
+| [MS Monaco Editor](https://github.com/Microsoft/monaco-editor) | [TypeFox](https://github.com/TypeFox) | [monaco-languageclient](https://www.npmjs.com/package/monaco-languageclient) |
+| [MS Paint IDE](https://ms-paint-i.de/) | [RubbaBoy](https://github.com/RubbaBoy) | [MS Paint IDE](https://github.com/MSPaintIDE/MSPaintIDE) |
+| [Multiple editors](https://github.com/Valloric/ycmd#known-ycmd-clients) | Ycmd team | [ycmd](https://github.com/Valloric/ycmd) | 
+| [Nova](https://nova.app) | [Panic Inc](http://panic.com) | Proprietary |
+| [Oni](https://www.onivim.io) | [@oni_vim](https://twitter.com/oni_vim) | [Oni's Features](https://www.onivim.io/Features) |
 | [Qt Creator](https://doc-snapshots.qt.io/qtcreator-4.9/creator-language-servers.html) | [The Qt Company](http://qt.io/) | [qtcreator](https://github.com/qt-creator/qt-creator)
-| [Acme](https://en.wikipedia.org/wiki/Acme_(text_editor)) | [Fazlul Shahriar](https://github.com/fhs) | [acme-lsp](https://github.com/fhs/acme-lsp) |
-| [Atom](https://atom.io/) | [GitHub](https://github.com/) | [atom-languageclient](https://www.npmjs.com/package/atom-languageclient) |
+| [RAD Studio](https://www.embarcadero.com/products/rad-studio) ([Delphi](https://www.embarcadero.com/products/delphi) and [C++Builder](https://www.embarcadero.com/products/cbuilder)) | [Embarcadero](https://www.embarcadero.com/) | Proprietary |
+| [Spyder](http://spyder-ide.org) | [Spyder Dev Team](https://github.com/spyder-ide) | [spyder](https://github.com/spyder-ide/spyder) | 
+| [Sublime Text](https://www.sublimetext.com/) | [Raoul Wols](https://github.com/rwols) | [lsp](https://github.com/sublimelsp/LSP) |
 | [Theia](https://github.com/theia-ide/theia) | [theia-ide](https://github.com/theia-ide) | [theia](https://github.com/theia-ide/theia) |
 | vim8 and [neovim](https://neovim.io/) | [Junfeng Li](https://github.com/autozimu) | [LanguageClient-neovim](https://github.com/autozimu/LanguageClient-neovim) |
 | vim8 and neovim | [Prabir Shrestha](https://github.com/prabirshrestha) | [vim-lsp](https://github.com/prabirshrestha/vim-lsp) |
 | vim8 and neovim | [Qiming Zhao](https://github.com/chemzqm) | [coc.nvim](https://github.com/neoclide/coc.nvim) |
+| vim8 and neovim| [Jimmy Huang](https://github.com/JimmyHuang454) | [EasyCompleteYou](https://github.com/JimmyHuang454/EasyCompleteYou) |
 | vim8 and neovim| [Nate Bosch](https://github.com/natebosch) | [vim-lsc](https://github.com/natebosch/vim-lsc) |
 | vim8 and neovim| [w0rp](https://github.com/w0rp) | [ALE (Asynchronous Lint Engine) ](https://github.com/w0rp/ale) |
-| vim8 and neovim| [Jimmy Huang](https://github.com/JimmyHuang454) | [EasyCompleteYou](https://github.com/JimmyHuang454/EasyCompleteYou) |
 | Visual Studio | [Adam Friedman](https://github.com/tintoy) | [LSP client in Visual Studio](https://github.com/tintoy/dotnet-language-client/tree/sample/visual-studio/samples/VisualStudioExtension) |
 | Visual Studio | Microsoft | [LSP Preview](https://marketplace.visualstudio.com/items?itemName=vsext.LanguageServerClientPreview) |
-| Oni | [@oni_vim](https://twitter.com/oni_vim) | [Oni's Features](https://www.onivim.io/Features) |
-| [Kakoune](http://kakoune.org/) | [ul](https://github.com/ul) | [kak-lsp](https://github.com/ul/kak-lsp) |
-| [Sublime Text](https://www.sublimetext.com/) | [Raoul Wols](https://github.com/rwols) | [lsp](https://github.com/sublimelsp/LSP) |
-| [Multiple editors](https://github.com/Valloric/ycmd#known-ycmd-clients) | Ycmd team | [ycmd](https://github.com/Valloric/ycmd) | 
-| [Brackets](http://brackets.io) | [Adobe](https://github.com/adobe) | [brackets](https://github.com/adobe/brackets) |
-| [Cloud Studio](https://studio.dev.tencent.com/) | CODING |  |
-| [CodeLite](https://codelite.org/) | [Eran Ifrah](https://github.com/eranif) | https://github.com/eranif/codelite |
-| [Spyder](http://spyder-ide.org) | [Spyder Dev Team](https://github.com/spyder-ide) | [spyder](https://github.com/spyder-ide/spyder) | 
-| [MS Paint IDE](https://ms-paint-i.de/) | [RubbaBoy](https://github.com/RubbaBoy) | [MS Paint IDE](https://github.com/MSPaintIDE/MSPaintIDE) |
-| [Aginity Pro](https://www.aginity.com/products/aginity-pro/) | [Aginity](https://www.aginity.com) | |
-| [Aginity Team](https://www.aginity.com/products/aginity-team/) | [Aginity](https://www.aginity.com) | |
-| [JupyterLab](https://github.com/jupyterlab/jupyterlab) | [krassowski](https://github.com/krassowski) | [jupyterlab-lsp](https://github.com/krassowski/jupyterlab-lsp) |
-| [Kate](https://kate-editor.org) | [Kate Team](https://kate-editor.org) | [kate](https://invent.kde.org/kde/kate) |
-| [JCIDE](https://www.javacardos.com/tools) | [Javacardos](https://www.javacardos.com) | [JCIDE](https://www.javacardos.com/javacardforum/viewtopic.php?f=5&t=2108&p=6175#p6175) |
-| [RAD Studio](https://www.embarcadero.com/products/rad-studio) ([Delphi](https://www.embarcadero.com/products/delphi) and [C++Builder](https://www.embarcadero.com/products/cbuilder)) | [Embarcadero](https://www.embarcadero.com/) | Proprietary |
-| [Nova](https://nova.app) | [Panic Inc](http://panic.com) | Proprietary |
-| [BBEdit](https://www.barebones.com/products/bbedit) | [Bare Bones Software, Inc.](https://www.barebones.com/) | Proprietary |
+| [Visual Studio Code](https://code.visualstudio.com) | Microsoft | [vscode](https://github.com/Microsoft/vscode/)  |
 {: .table .table-bordered .table-responsive}


### PR DESCRIPTION
That makes it arguably easier to scan the table visually.

I also changed the two entries labelled `emacs` resp. `GNU Emacs` to both say `Emacs`
(an alternative would be to leave them as `GNU Emacs` but sort them under `Emacs`).

There are some more entries one may argue about, e.g. should "GNOME Builder" be sorted
under "G" or "B"? What about "MS Monaco"?

Finally, one entry says "Multiple editors"; the underlying ycmd tool supports Emacs,
vim, atom, sublime, geany, kakoune, nano, ... perhaps it should be listed multiple times?
