### PR TITLE
Add CoffeeSense (CoffeeScript LSP)

### DIFF
--- a/_implementors/servers.md
+++ b/_implementors/servers.md
@@ -37,6 +37,7 @@ index: 1
 | IBM Enterprise **COBOL** for z/OS | [Broadcom](https://www.broadcom.com/) | [COBOL Language Support](https://github.com/eclipse/che-che4z-lsp-for-cobol) | Java |
 | [IBM Enterprise **COBOL** for z/OS](https://www.ibm.com/support/knowledgecenter/SS6SG3_6.3.0/welcome.html) | IBM |  [IBM Z Open Editor VS Code extension](https://marketplace.visualstudio.com/items?itemName=IBM.zopeneditor) | Java |
 | [CodeQL](https://securitylab.github.com/tools/codeql) | [GitHub](https://github.com/github/codeql) | [codeql](https://github.com/github/codeql) | Java |
+| [CoffeeScript](https://coffeescript.org/) | [phil294](https://github.com/phil294/) | [CoffeeSense](https://github.com/phil294/coffeesense/) | TypeScript
 | [CWL](https://www.commonwl.org/) | [Rabix](https://github.com/rabix) | [Benten](https://github.com/rabix/benten) | Python |
 | [Crystal](https://crystal-lang.org/)| [Elbaz Julien](https://github.com/elbywan) | [Crystalline](https://github.com/elbywan/crystalline) | Crystal |
 | [Crystal](https://crystal-lang.org/)| [Ryan L. Bell](https://github.com/kofno) | [Scry](https://github.com/crystal-lang-tools/scry) | Crystal |


### PR DESCRIPTION
This LSP implementation at hand is a bit unusual in that it does not natively parse and understand the source code but instead,
- compiles it to JavaScript
- feeds the JS to tsserver
- maps back TS response using source maps

---

This principle can also be applied to other [languages that compile to JavaScript](https://github.com/jashkenas/coffeescript/wiki/List-of-languages-that-compile-to-JS) (there are many), given they are somewhat relevant, don't have a lsp impl or type checks yet and also emit source maps (not so many). Matching this criteria are:
- [LiveScript](https://livescript.net/)
- [IcedCoffeeScript](http://maxtaco.github.io/coffee-script)
- [Sibilant](https://github.com/jbr/sibilant)
- [LiteScript](https://github.com/luciotato/LiteScript)
- [Cor](http://yosbelms.github.io/cor/)
- [streamline.js](https://github.com/Sage/streamlinejs)

It should be a minor effort to port CoffeeSense to either of these candidates for rudimentary LSP. These will probably support validation, hover, highlight, definition and references, basic autocompletion and possibly also signature type hints.
I want to do this some day, but not yet sure when.
This would essentially mean six new entries to this list, all low-effort, similar codebase, but working.