### PR TITLE
semantic highlighting range, does not return delta

### DIFF
--- a/_specifications/specification-3-16.md
+++ b/_specifications/specification-3-16.md
@@ -7864,7 +7864,7 @@ export interface SemanticTokensRangeParams extends WorkDoneProgressParams,
 
 _Response_:
 
-* result: `SemanticTokens | null` where `SemanticTokensDelta`
+* result: `SemanticTokens | null`
 * partial result: `SemanticTokensPartialResult`
 * error: code and message set in case an exception happens during the 'textDocument/semanticTokens/range' request
 

--- a/_specifications/specification-3-17.md
+++ b/_specifications/specification-3-17.md
@@ -8611,7 +8611,7 @@ export interface SemanticTokensRangeParams extends WorkDoneProgressParams,
 
 _Response_:
 
-* result: `SemanticTokens | null` where `SemanticTokensDelta`
+* result: `SemanticTokens | null`
 * partial result: `SemanticTokensPartialResult`
 * error: code and message set in case an exception happens during the 'textDocument/semanticTokens/range' request
 


### PR DESCRIPTION
For section "Requesting semantic tokens for a range", it does not return `SemanticTokensDelta`

Looks like this is a copy pasta bug from the previous(tokens delta) section

updated in both 3.16 and 3.17