### PR TITLE
Make specification more uniform to improve automatic parsing

### DIFF
--- a/_specifications/specification-3-16.md
+++ b/_specifications/specification-3-16.md
@@ -969,7 +969,7 @@ export interface WorkspaceEdit {
 
 
 The capabilities of a workspace edit has evolved over the time. Clients can describe their support using the following client capability:
-
+_Client Capability_:
 * property path (optional): `workspace.workspaceEdit`
 * property type: `WorkspaceEditClientCapabilities` defined as follows:
 
@@ -3322,7 +3322,7 @@ export interface ExecuteCommandRegistrationOptions
 }
 ```
 
-_Request:_
+_Request_:
 * method: 'workspace/executeCommand'
 * params: `ExecuteCommandParams` defined as follows:
 
@@ -4169,7 +4169,7 @@ See also the [Diagnostic](#diagnostic) section.
 
 _Client Capability_:
 * property name (optional): `textDocument.publishDiagnostics`
-* property type `PublishDiagnosticsClientCapabilities` defined as follows:
+* property type: `PublishDiagnosticsClientCapabilities` defined as follows:
 
 ```typescript
 export interface PublishDiagnosticsClientCapabilities {


### PR DESCRIPTION
Some minor type fixes that did help my automatic parsing of the specification to generate a c++ implementation of LSP:

* always use "_Client Capability_:" before client capabilities
* correct typo putting colon before_
* always add colon after "* property type"