### PR TITLE
Restrict linking to only the 3-17 specification.

### DIFF
--- a/_includes/js_files.html
+++ b/_includes/js_files.html
@@ -17,7 +17,6 @@
 <script async defer src="https://buttons.github.io/buttons.js"></script>
 <script src="{{ site.baseurl }}/js/page.js"></script>
 
-
 <script type="text/javascript">
   var linkableTypes = {
   {% for linkableGroup in site.data.linkableTypes %}
@@ -29,6 +28,11 @@
 </script>
 
 <script type="text/javascript">
+  if (window.location.pathname.indexOf("3-17") === -1) {
+    // Currently we don't support linking on other versions of the document.
+    return;
+  }
+
   function tryGetAssociatedLink(name) {
     var link = linkableTypes[name];
 


### PR DESCRIPTION
- I tried making linking >= 3-17; however, that wasn't easily doable due to the structure of the jekyll site. The JSFiles themselves are included in the layout which don't have access to page level information. Because of this I've hacked a hardcoded "if 3.17" check into the injected JavaScript to support linking. Once we publish 3.17 we'll need to go back and update the logic to ensure that 3.17+ is supported.

Originally attempted fix here: https://github.com/microsoft/language-server-protocol/pull/1342