### PR TITLE
Add D language ID, fix #1379

### DIFF
--- a/_specifications/specification-3-14.md
+++ b/_specifications/specification-3-14.md
@@ -666,6 +666,7 @@ C | `c`
 C++ | `cpp`
 C# | `csharp`
 CSS | `css`
+D | `d`
 Diff | `diff`
 Dart | `dart`
 Dockerfile | `dockerfile`

--- a/_specifications/specification-3-15.md
+++ b/_specifications/specification-3-15.md
@@ -831,6 +831,7 @@ C | `c`
 C++ | `cpp`
 C# | `csharp`
 CSS | `css`
+D | `d`
 Diff | `diff`
 Dart | `dart`
 Dockerfile | `dockerfile`

--- a/_specifications/specification-3-16.md
+++ b/_specifications/specification-3-16.md
@@ -1134,6 +1134,7 @@ C | `c`
 C++ | `cpp`
 C# | `csharp`
 CSS | `css`
+D | `d`
 Diff | `diff`
 Dart | `dart`
 Dockerfile | `dockerfile`

--- a/_specifications/specification-3-17.md
+++ b/_specifications/specification-3-17.md
@@ -1264,6 +1264,7 @@ C | `c`
 C++ | `cpp`
 C# | `csharp`
 CSS | `css`
+D | `d`
 Diff | `diff`
 Dart | `dart`
 Dockerfile | `dockerfile`


### PR DESCRIPTION
just adds D to the language ID tables that recommend file type meanings as it is a fairly established language and is already used in all D LSPs (dls, serve-d) like this and fits the other naming conventions like for `C`

Changes nothing in semantics or protocol definitions.