### PR TITLE
Make versions consistently have type uinteger

### DIFF
--- a/_specifications/specification-3-17.md
+++ b/_specifications/specification-3-17.md
@@ -1242,7 +1242,7 @@ interface TextDocumentItem {
 	 * The version number of this document (it will increase after each
 	 * change, including undo/redo).
 	 */
-	version: integer;
+	version: uinteger;
 
 	/**
 	 * The content of the opened text document.
@@ -1324,7 +1324,7 @@ interface VersionedTextDocumentIdentifier extends TextDocumentIdentifier {
 	 * The version number of a document will increase after each change,
 	 * including undo/redo. The number doesn't need to be consecutive.
 	 */
-	version: integer;
+	version: uinteger;
 }
 ```
 
@@ -1345,7 +1345,7 @@ interface OptionalVersionedTextDocumentIdentifier extends TextDocumentIdentifier
 	 * The version number of a document will increase after each change,
 	 * including undo/redo. The number doesn't need to be consecutive.
 	 */
-	version: integer | null;
+	version: uinteger | null;
 }
 ```
 


### PR DESCRIPTION
`PublishDiagnosticParams` has its `version` field specified as a
`uinteger`, but other occurences of `version` are `integer`s.

This is inconsistent, and results in servers having to do
(theoretically) lossy conversions to `uinteger`s when creating
`PublishDiagnostics` notifications.

It seems to me that versions probably _should_ be `uintegers` (starting
at 0 and monotonically increasing), so this changes the other places to
use `uinteger`.

I suspect this will have no effect on implementations, but in theory
this could cause trouble for any clients who currently make use of
negative versions for something.