### PR TITLE
Added `fortls` Fortran LS

### DIFF
--- a/_implementors/servers.md
+++ b/_implementors/servers.md
@@ -61,6 +61,7 @@ index: 1
 | F# | [@georgewfraser](https://github.com/georgewfraser) | [F# Language Server](https://github.com/georgewfraser/fsharp-language-server) | F# |
 | F# | [@Krzysztof-Cieslak](https://github.com/Krzysztof-Cieslak) & Contributors | [FsAutoComplete](https://github.com/fsharp/FsAutoComplete) | F# |
 | Fortran | [Chris Hansen](https://github.com/hansec) | [fortran-language-server](https://github.com/hansec/fortran-language-server) | Python |
+| [Fortran](https://fortran-lang.org/) | [Giannis Nikiteas](https://github.com/gnikit) | [fortls](https://github.com/gnikit/fortls) | Python |
 | [Fuzion](https://flang.dev) | [Tokiwa Software GmbH](https://tokiwa.software) | [Fuzion Language Server](https://github.com/tokiwa-software/fuzion-lsp-server) | Java, Fuzion |
 | GLSL | [Sven-Hendrik Haase (@svenstaro)](https://github.com/svenstaro) | [glsl-language-server](https://github.com/svenstaro/glsl-language-server) | C++ |
 | Gauge | [Gauge](https://github.com/getgauge) | [Gauge Language Server](https://github.com/getgauge/gauge/) | Go |


### PR DESCRIPTION
Added `fortls` Language Server for Fortran, which started as a fork of the `fortran-language-server` (which appears to be unmaintained for the past 2y).
`fortls` since its original creation has diverged substantially from its upstream so I think it is reasonable for it to be included as a separate entry.