### PR TITLE
use language id for consistence

### DIFF
--- a/_specifications/specification-3-14.md
+++ b/_specifications/specification-3-14.md
@@ -2559,7 +2559,7 @@ export interface ApplyWorkspaceEditResponse {
 
 The document open notification is sent from the client to the server to signal newly opened text documents. The document's truth is now managed by the client and the server must not try to read the document's truth using the document's Uri. Open in this sense means it is managed by the client. It doesn't necessarily mean that its content is presented in an editor. An open notification must not be sent more than once without a corresponding close notification send before. This means open and close notification must be balanced and the max open count for a particular textDocument is one. Note that a server's ability to fulfill requests is independent of whether a text document is open or closed.
 
-The `DidOpenTextDocumentParams` contain the language id the document is associated with. If the language Id of a document changes, the client needs to send a `textDocument/didClose` to the server followed by a `textDocument/didOpen` with the new language id if the server handles the new language id as well.
+The `DidOpenTextDocumentParams` contain the language id the document is associated with. If the language id of a document changes, the client needs to send a `textDocument/didClose` to the server followed by a `textDocument/didOpen` with the new language id if the server handles the new language id as well.
 
 _Notification_:
 * method: 'textDocument/didOpen'

--- a/_specifications/specification-3-16.md
+++ b/_specifications/specification-3-16.md
@@ -3793,7 +3793,7 @@ export interface TextDocumentSyncOptions {
 
 The document open notification is sent from the client to the server to signal newly opened text documents. The document's content is now managed by the client and the server must not try to read the document's content using the document's Uri. Open in this sense means it is managed by the client. It doesn't necessarily mean that its content is presented in an editor. An open notification must not be sent more than once without a corresponding close notification send before. This means open and close notification must be balanced and the max open count for a particular textDocument is one. Note that a server's ability to fulfill requests is independent of whether a text document is open or closed.
 
-The `DidOpenTextDocumentParams` contain the language id the document is associated with. If the language Id of a document changes, the client needs to send a `textDocument/didClose` to the server followed by a `textDocument/didOpen` with the new language id if the server handles the new language id as well.
+The `DidOpenTextDocumentParams` contain the language id the document is associated with. If the language id of a document changes, the client needs to send a `textDocument/didClose` to the server followed by a `textDocument/didOpen` with the new language id if the server handles the new language id as well.
 
 _Client Capability_:
 See general synchronization [client capabilities](#textDocument_synchronization_cc).

--- a/_specifications/specification-3-17.md
+++ b/_specifications/specification-3-17.md
@@ -4183,7 +4183,7 @@ export interface TextDocumentSyncOptions {
 
 The document open notification is sent from the client to the server to signal newly opened text documents. The document's content is now managed by the client and the server must not try to read the document's content using the document's Uri. Open in this sense means it is managed by the client. It doesn't necessarily mean that its content is presented in an editor. An open notification must not be sent more than once without a corresponding close notification send before. This means open and close notification must be balanced and the max open count for a particular textDocument is one. Note that a server's ability to fulfill requests is independent of whether a text document is open or closed.
 
-The `DidOpenTextDocumentParams` contain the language id the document is associated with. If the language Id of a document changes, the client needs to send a `textDocument/didClose` to the server followed by a `textDocument/didOpen` with the new language id if the server handles the new language id as well.
+The `DidOpenTextDocumentParams` contain the language id the document is associated with. If the language id of a document changes, the client needs to send a `textDocument/didClose` to the server followed by a `textDocument/didOpen` with the new language id if the server handles the new language id as well.
 
 _Client Capability_:
 See general synchronization [client capabilities](#textDocument_synchronization_cc).


### PR DESCRIPTION
`language id`(lower case) is used in all the SPEC, but there is only one `language Id`(upper case for `I`).

it is not consistent, and also may lead to confusion between `l(lower case L)` and `I(upper case i)`, the [SPEC page](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_didOpen), for example:

![image](https://user-images.githubusercontent.com/3764335/153133744-f890abfc-f320-48d9-92c9-686fc71519c5.png)
