### PR TITLE
Add padding to more links

### DIFF
--- a/css/main.scss
+++ b/css/main.scss
@@ -479,7 +479,7 @@ code.highlighter-rouge a {
 	font-weight: bold;
 }
 
-a h3 {
+a h3, h3 a, h4 a {
 	padding-top: 2px;
 	padding-bottom: 2px;
 }


### PR DESCRIPTION
This PR adds more CSS rules to fix some outline shapes to look more rectangular.
Ref https://github.com/microsoft/debug-adapter-protocol/issues/252
An example of the new outline:
![Screenshot showing a nice and rectangular outline around an element that has been focused with a keyboard](https://user-images.githubusercontent.com/7199958/157315893-d38371ad-0339-4c6a-aa18-83b19efb61d5.PNG)
