### PR TITLE
Recommend WorkspaceSymbol

### DIFF
--- a/_specifications/lsp/3.17/types/partialResults.md
+++ b/_specifications/lsp/3.17/types/partialResults.md
@@ -2,7 +2,7 @@
 
 > *Since version 3.15.0*
 
-Partial results are also reported using the generic [`$/progress`](#progress) notification. The value payload of a partial result progress notification is in most cases the same as the final result. For example the `workspace/symbol` request has `SymbolInformation[]` as the result type. Partial result is therefore also of type `SymbolInformation[]`. Whether a client accepts partial result notifications for a request is signaled by adding a `partialResultToken` to the request parameter. For example, a `textDocument/reference` request that supports both work done and partial result progress might look like this:
+Partial results are also reported using the generic [`$/progress`](#progress) notification. The value payload of a partial result progress notification is in most cases the same as the final result. For example the `workspace/symbol` request has `SymbolInformation[]` \| `WorkspaceSymbol[]` as the result type. Partial result is therefore also of type `SymbolInformation[]` \| `WorkspaceSymbol[]`. Whether a client accepts partial result notifications for a request is signaled by adding a `partialResultToken` to the request parameter. For example, a `textDocument/reference` request that supports both work done and partial result progress might look like this:
 
 ```json
 {

--- a/_specifications/lsp/3.17/workspace/symbol.md
+++ b/_specifications/lsp/3.17/workspace/symbol.md
@@ -110,7 +110,7 @@ interface WorkspaceSymbolParams extends WorkDoneProgressParams,
 ```
 
 _Response_:
-* result: `SymbolInformation[]` \| `WorkspaceSymbol[]` \| `null`. See above for the definition of `SymbolInformation`. `WorkspaceSymbol` is defined as follows:
+* result: `SymbolInformation[]` \| `WorkspaceSymbol[]` \| `null`. See above for the definition of `SymbolInformation`. It is recommended that you use `WorkspaceSymbol`, which is defined as follows:
 
 <div class="anchorHolder"><a href="#workspaceSymbol" name="workspaceSymbol" class="linkableAnchor"></a></div>
 


### PR DESCRIPTION
- With `SymbolInformation` now deprecated, making it clear to recommend `WorkspaceSymbol` as the result for `workspace/symbol` instead.

- Updated example for Partial Result Progress with new result for `workspace/symbol`.