### PR TITLE
Add `workspace.inlayHint` to capabilities

### DIFF
--- a/_specifications/lsp/3.17/general/initialize.md
+++ b/_specifications/lsp/3.17/general/initialize.md
@@ -402,6 +402,13 @@ interface ClientCapabilities {
 			 */
 			willDelete?: boolean;
 		};
+
+		/**
+		 * Client workspace capabilities specific to inlay hints.
+		 *
+		 * @since 3.17.0 - proposed state
+		 */
+		inlayHint?: InlayHintWorkspaceClientCapabilities;
 	};
 
 	/**


### PR DESCRIPTION
`workspace.inlayHint` is defined in spec but missing from `ClientCapabilities`.