### PR TITLE
Add `workspace.inlineValue` to capabilities

### DIFF
--- a/_specifications/lsp/3.17/general/initialize.md
+++ b/_specifications/lsp/3.17/general/initialize.md
@@ -404,6 +404,13 @@ interface ClientCapabilities {
 		};
 
 		/**
+		 * Client workspace capabilities specific to inline values.
+		 *
+		 * @since 3.17.0 - proposed state
+		 */
+		inlineValue?: InlineValueWorkspaceClientCapabilities;
+
+		/**
 		 * Client workspace capabilities specific to inlay hints.
 		 *
 		 * @since 3.17.0 - proposed state


### PR DESCRIPTION
`workspace.inlineValue` is defined in spec but missing from `ClientCapabilities`.