### PR TITLE
Update DocumentDiagnosticReportKind case

### DIFF
--- a/_specifications/lsp/3.17/language/pullDiagnostics.md
+++ b/_specifications/lsp/3.17/language/pullDiagnostics.md
@@ -152,13 +152,13 @@ export namespace DocumentDiagnosticReportKind {
 	 * A diagnostic report with a full
 	 * set of problems.
 	 */
-	export const full = 'full';
+	export const Full = 'full';
 
 	/**
 	 * A report indicating that the last
 	 * returned report is still accurate.
 	 */
-	export const unchanged = 'unchanged';
+	export const Unchanged = 'unchanged';
 }
 
 export type DocumentDiagnosticReportKind = 'full' | 'unchanged';
@@ -177,7 +177,7 @@ export type FullDocumentDiagnosticReport = {
 	/**
 	 * A full document diagnostic report.
 	 */
-	kind: DocumentDiagnosticReportKind.full;
+	kind: DocumentDiagnosticReportKind.Full;
 
 	/**
 	 * An optional result id. If provided it will
@@ -210,7 +210,7 @@ export type UnchangedDocumentDiagnosticReport = {
 	 * only return `unchanged` if result ids are
 	 * provided.
 	 */
-	kind: DocumentDiagnosticReportKind.unChanged;
+	kind: DocumentDiagnosticReportKind.Unchanged;
 
 	/**
 	 * A result id which will be sent on the next


### PR DESCRIPTION
Changing `DocumentDiagnosticReportKind` kinds to match the case convention used by other *-`Kind`s.