### PR TITLE
Fix `WatchKind.type.name` to match JSON Schema

### DIFF
--- a/_specifications/lsp/3.17/metaModel/metaModel.json
+++ b/_specifications/lsp/3.17/metaModel/metaModel.json
@@ -13422,7 +13422,7 @@
 			"name": "WatchKind",
 			"type": {
 				"kind": "base",
-				"name": "uinteger"
+				"name": "integer"
 			},
 			"values": [
 				{


### PR DESCRIPTION
If I understand JSON Schema right `uinteger` isn't allowed value of `name` property (only `string` and `integer` are allowed):
```json
    "EnumerationType": {
      "properties": {
        "name": {
          "enum": [
            "string",
            "integer"
          ],
          "type": "string"
        }
```