### PR TITLE
Added entry for OpenRA.MiniYAML language server

### DIFF
--- a/_implementors/servers.md
+++ b/_implementors/servers.md
@@ -187,6 +187,7 @@ index: 1
 | WXML| [Qiming Zhao](https://github.com/chemzqm)| [wxml-languageserver](https://github.com/chemzqm/wxml-languageserver) | TypeScript |
 | XML | IBM | [XML Language Server](https://github.com/microclimate-devops/xml-language-server) | Java |
 | XML | [Red Hat Developers](https://github.com/redhat-developer) and [Angelo ZERR](https://github.com/angelozerr/) | [XML Language Server (LemMinX)](https://github.com/eclipse/lemminx) | Java |
+| [Mini**YAML**](https://github.com/OpenRA/MiniYAML.tmbundle) | [Pavel Penev](https://github.com/penev92) | [ORAIDE](https://github.com/penev92/Oraide.LanguageServer) | C# |
 | YAML (with JSON schemas)| [Adam Voss](https://github.com/adamvoss) | [vscode-yaml-languageservice](https://github.com/adamvoss/vscode-yaml-languageservice) | TypeScript |
 | YAML| [Red Hat Developers](https://github.com/redhat-developer) | [yaml-language-server](https://github.com/redhat-developer/yaml-language-server) | TypeScript |
 | [YANG](https://tools.ietf.org/html/rfc7950)| [Yang tools](https://github.com/yang-tools) | [yang-lsp](https://github.com/yang-tools/yang-lsp) |  XTend |


### PR DESCRIPTION
Added (questionably) next to the YAML entry because I saw `IBM LALR` is done in a similar way but I could move it if needed.
I don't know what the criteria for being added as a Language Server implementation is, so here is the real-life use-case of this one: https://marketplace.visualstudio.com/items?itemName=openra.oraide-vscode