### PR TITLE
Add supporting tools entry for CodeMirror 6

### DIFF
--- a/_implementors/tools.md
+++ b/_implementors/tools.md
@@ -18,6 +18,7 @@ index: 2
 | [Brackets](http://brackets.io) | [Adobe](https://github.com/adobe) | [brackets](https://github.com/adobe/brackets) |
 | [Cloud Studio](https://studio.dev.tencent.com/) | CODING |  |
 | [CodeLite](https://codelite.org/) | [Eran Ifrah](https://github.com/eranif) | https://github.com/eranif/codelite |
+| [CodeMirror](https://codemirror.net/6/) | [Furqan Software](https://github.com/furqansoftware) | [codemirror-languageserver](https://github.com/furqansoftware/codemirror-languageserver) |
 | [Eclipse Che](https://www.eclipse.org/che/) | Eclipse,Codenvy/TypeFox | [Che](https://github.com/eclipse/che/issues/1287) |
 | Eclipse IDE | Eclipse,Red Hat | [Eclipse community](https://projects.eclipse.org/projects/technology.lsp4e/who), [Eclipse LSP4E](https://projects.eclipse.org/projects/technology.lsp4e) |
 | Emacs | [Vibhav Pant](https://github.com/vibhavp) | [emacs language server client](https://github.com/emacs-lsp/lsp-mode/) |


### PR DESCRIPTION
[CodeMirror 6](https://codemirror.net/6/) is a rewrite of the CodeMirror editor which is close to maturity. 

The package [codemirror-languageserver](https://www.npmjs.com/package/codemirror-languageserver) provides an LSP client for the CodeMirror 6 editor. The package is maintained through GitHub: https://github.com/FurqanSoftware/codemirror-languageserver.

