### PR TITLE
SemanticTokensLegend uses enums

### DIFF
--- a/_specifications/lsp/3.17/language/semanticTokens.md
+++ b/_specifications/lsp/3.17/language/semanticTokens.md
@@ -85,12 +85,12 @@ export interface SemanticTokensLegend {
 	/**
 	 * The token types a server uses.
 	 */
-	tokenTypes: string[];
+	tokenTypes: SemanticTokenTypes[];
 
 	/**
 	 * The token modifiers a server uses.
 	 */
-	tokenModifiers: string[];
+	tokenModifiers: SemanticTokenModifiers[];
 }
 ```
 


### PR DESCRIPTION
Fixes #1503.

I'm happy to update the metamodel too, but I'm not sure where to do it now - in the `vscode-languageserver-node` repo or here?