### PR TITLE
Customize the redirect template

### DIFF
--- a/_layouts/redirect.html
+++ b/_layouts/redirect.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en-US">
+  <meta charset="utf-8">
+  <title>Redirecting&hellip;</title>
+  <link rel="canonical" href="{{ page.redirect.to }}">
+  <script>location="{{ page.redirect.to }}".concat(location.hash)</script>
+  <meta http-equiv="refresh" content="0; url={{ page.redirect.to }}">
+  <meta name="robots" content="noindex">
+  <h1>Redirecting&hellip;</h1>
+  <a href="{{ page.redirect.to }}">Click here if you are not redirected.</a>
+</html>


### PR DESCRIPTION
Fixes #1505

Customize the redirect.html template to perform a client side
javascript redirect that reads the window.location.hash and appends it
to the destination URL, before redirecting.

See https://github.com/jekyll/jekyll-redirect-from/issues/219