### PR TITLE
Add missing link type

### DIFF
--- a/_data/linkableTypes.yml
+++ b/_data/linkableTypes.yml
@@ -820,6 +820,8 @@
     link: '#versionedNotebookDocumentIdentifier'
   - type: 'DiagnosticClientCapabilities'
     link: '#diagnosticClientCapabilities'
+  - type: 'DiagnosticWorkspaceClientCapabilities'
+    link: '#diagnosticWorkspaceClientCapabilities'
   - type: 'DiagnosticOptions'
     link: '#diagnosticOptions'
   - type: 'DiagnosticRegistrationOptions'


### PR DESCRIPTION
Adding the link type for `DiagnosticWorkspaceClientCapabilities`.