### PR TITLE
[jekyll] Ignore folders generated by Bundler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 npm-debug.log
-_site
+_site/
+.bundle/
+vendor/

--- a/_config.yml
+++ b/_config.yml
@@ -24,7 +24,8 @@ exclude:
   - .idea/
   - .gitignore
   - README.md
-  - resources
+  - resources/
+  - vendor/
 
 timezone: Europe/Zurich
 


### PR DESCRIPTION
Ignore the `vendor/` and `.bundle/` folders since they contain user- or
platform-specific information.

See https://jekyllrb.com/tutorials/using-jekyll-with-bundler