### PR TITLE
PSP version 0.1

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,12 +1,12 @@
 # Site settings
-title: Official page for Language Server Protocol
+title: Official page for Plugin Server Protocol
 description: >
-  Language Server Protocol documentation and specification page.
+  Plugin Server Protocol documentation and specification page.
 
-baseurl: /language-server-protocol # the subpath of your site, e.g. /blog/
-url: https://microsoft.github.io # the base hostname & protocol for your site
-git_address: https://github.com/Microsoft/language-server-protocol
-git_edit_address: https://github.com/Microsoft/language-server-protocol/blob/gh-pages
+baseurl: /plugin-server-protocol # the subpath of your site, e.g. /blog/
+url: https://lapce.dev # the base hostname & protocol for your site
+git_address: https://github.com/lapce/plugin-server-protocol
+git_edit_address: https://github.com/lapce/plugin-server-protocol/blob/gh-pages
 
 # Build settings
 markdown: kramdown
@@ -17,7 +17,6 @@ plugins:
   - jemoji
   - jekyll-redirect-from
 
-
 exclude:
   - Gemfile
   - Gemfile.lock
@@ -27,30 +26,29 @@ exclude:
   - resources/
   - vendor/
 
-timezone: Europe/Zurich
+timezone: Europe/Paris
 
 defaults:
+  - scope:
+      path: _implementors
+      type: implementors
+    values:
+      layout: implementors
+      sectionid: implementors
 
-- scope:
-    path: _implementors
-    type: implementors
-  values:
-    layout: implementors
-    sectionid: implementors
+  - scope:
+      path: _specifications
+      type: specifications
+    values:
+      layout: specifications
+      sectionid: specifications
 
-- scope:
-    path: _specifications
-    type: specifications
-  values:
-    layout: specifications
-    sectionid: specifications
-
-- scope:
-    path: _overviews
-    type: overviews
-  values:
-    layout: overviews
-    sectionid: overviews
+  - scope:
+      path: _overviews
+      type: overviews
+    values:
+      layout: overviews
+      sectionid: overviews
 
 collections:
   implementors:
@@ -62,4 +60,3 @@ collections:
   overviews:
     permalink: /:collection/:path/
     output: true
-

--- a/index.html
+++ b/index.html
@@ -8,10 +8,14 @@ layout: default
 <div class="header-container bg-primary jumbotron">
     <div class="container">
         <div class="intro" role="navigation" aria-label="Main">
-            <h1>Language Server Protocol</h1>
+            <h1>Plugin Server Protocol</h1>
         </div>
         <p class="intro-text">
-            The Language Server Protocol (LSP) defines the protocol used between an editor or IDE and a language server that provides language features like auto complete, go to definition, find all references etc. The goal of the Language Server Index Format (LSIF, pronounced like "else if") is to support rich code navigation in development tools or a Web UI without needing a local copy of the source code.
+            The Plugin Server Protocol (PSP) defines the protocol used between an editor or IDE and a plugin server that provides features extending or communicating with said IDE. The goal of the Plugin Server Protocol is to declare a generalized superset of the Language Server Protocol (LSP) for plugin contexts.
+        </p>
+        <br />
+        <p class="intro-text">
+            The plugin Server Protocol is directly based on the Language Server protocol (LSP), created by Microsoft for Visual Studio Code.
         </p>
 
         <br />
@@ -25,12 +29,14 @@ layout: default
 <div class="container">
     <div class="row align-items-center">
         <div class="col-lg-7">
-            <h2 class="header-light regular-pad">What is the Language Server Protocol?</h2>
+            <h2 class="header-light regular-pad">What is the Plugin Server Protocol?</h2>
 
-            <p>Adding features like auto complete, go to definition, or documentation on hover for a programming language takes significant effort. Traditionally this work had to be repeated for each development tool, as each tool provides different APIs for implementing the same feature.</p>
-            <p>A <i>Language Server</i> is meant to provide the language-specific smarts and communicate with development tools over a protocol that enables inter-process communication.</p>
-            <p>The idea behind the <i>Language Server Protocol (LSP)</i> is to standardize the protocol for how such servers and development tools communicate. This way, a single <i>Language Server</i> can be re-used in multiple development tools, which in turn can support multiple languages with minimal effort.</p>
-            <p>LSP is a win for both language providers and tooling vendors!</p>
+            <p>Extending IDEs and editors such as VsCode, Atom, Vim or Emacs can be a hassle. While there is a common denominator for language servers using the Language Server Procol (LSP), there is no consensus for plugins. Traditionally once a plugin is done for a specific editor, the work has to be repeated for each development tool, as each tool provides different APIs for implementing the same feature.</p>
+            <p>A <i>Plugin Server</i> is meant to provide the fancy cool features and communicate with development tools over a protocol that enables inter-process communication geared toward plugin needs, based on LSP.</p>
+
+            <p>The idea behind the <i>Plugin Server Protocol (PSP)</i> is to standardize the protocol for how such servers and development tools communicate. This way, a single <i>Plugin Server</i> can be re-used in multiple development tools with minimal effort.</p>
+            <p>The idea behind using LSP as a basis is to extend an already successfull generalized approach to language server, and bring the benefits to all plugins. </p>
+            <p>PSP is a win for both language providers and tooling vendors!</p>
         </div>
         <div class="col-lg-5">
             <div id="carouselOne" class="carousel slide" data-ride="carousel">


### PR DESCRIPTION
This PR is the first PR of the PSP specification.

As mentioned in the documentation, the PSP specification is a superset of the LSP spec to create a generalized plugin experience.

Here is a list of things to do before merging:

- [ ] Remove the Microsoft branding to avoid copyright issues
- [ ] Remove the whole cookie system
- [ ] Change the visuals on the main page to PSP visuals
- [ ] Link the Requests / notifications reused reused from LSP
- [ ] Add new Requests / notifications of the PSP

Feel free to comment if I forgot anything.