### PR TITLE
Fix links in the documentation

### DIFF
--- a/_data/specifications.yml
+++ b/_data/specifications.yml
@@ -2,8 +2,10 @@
   anchor: lsp
   children:
   - title: 3.17 (Current)
+    version: 3.17
     url: /specifications/lsp/3.17/specification
   - title: 3.16 (Previous)
+    version: 3.16
     url: /specifications/specification-3-16
 - title: LSIF
   anchor: lsif

--- a/_includes/js_files.html
+++ b/_includes/js_files.html
@@ -19,13 +19,13 @@
 
 
 <script type="text/javascript">
-  var linkableTypes = {
-  {% for linkableGroup in site.data.linkableTypes %}
-  {% for linkableType in linkableGroup.children %}
-  "{{ linkableType.type }}": "{{ linkableType.link }}",
-    {% endfor %}
-  {% endfor %}
-  };
+  var linkableTypes = new Map([
+  {% for linkableGroup in site.data.linkableTypes -%}
+  {% for linkableType in linkableGroup.children -%}
+    ["{{ linkableType.type }}", "{{ linkableType.link }}"],
+    {% endfor -%}
+  {% endfor -%}
+  ]);
 </script>
 
 {% comment %}
@@ -41,7 +41,7 @@
 
 <script type="text/javascript">
   function tryGetAssociatedLink(name) {
-    var link = linkableTypes[name];
+    var link = linkableTypes.get(name);
 
     if (!link) {
       return;

--- a/_includes/js_files.html
+++ b/_includes/js_files.html
@@ -28,6 +28,17 @@
   };
 </script>
 
+{% comment %}
+// Get the current LSP spec base url from the site data
+{% endcomment %}
+{% for spec in site.data.specifications %}
+{%  for child in spec.children %}
+{%   if spec.anchor == 'lsp' and child.version == page.lspVersion %}
+{%    assign currentSpecification = child.url %}
+{%   endif %}
+{%  endfor %}
+{% endfor %}
+
 <script type="text/javascript">
   function tryGetAssociatedLink(name) {
     var link = linkableTypes[name];
@@ -37,10 +48,13 @@
     }
 
     var anchor = document.createElement("a");
-    var currentSpecification = 'lsp/3.17/specification';
     var hrefUrl = link[0] === '/' ?
       `${baseurl}/specifications${link}` :
-      `${baseurl}/specifications/${currentSpecification}/${link}`;
+{% if currentSpecification %}
+      `${baseurl}{{ currentSpecification }}/${link}`;
+{% else %}
+      link;
+{% endif %}
     anchor.setAttribute("href", hrefUrl);
     anchor.textContent = name;
     return anchor;
@@ -49,7 +63,6 @@
   var elements = document.querySelectorAll("code .nx, code.highlighter-rouge");
   for (var element of elements) {
     var typeName = element.textContent;
-    var link = linkableTypes[typeName];
     var linkNode = tryGetAssociatedLink(typeName);
 
     if (linkNode) {

--- a/_specifications/lsif/0.5.0/specification.md
+++ b/_specifications/lsif/0.5.0/specification.md
@@ -6,6 +6,7 @@ sectionid: lsif-0-5-0
 toc: lsif-0-5-0-toc
 index: 2
 fullTitle: Language Server Index Format Specification - 0.5.0
+lspVersion: 3.17
 ---
 
 The 0.5.0 version of LSIF is currently under construction.

--- a/_specifications/lsif/0.6.0/specification.md
+++ b/_specifications/lsif/0.6.0/specification.md
@@ -6,6 +6,7 @@ sectionid: lsif-0-6-0
 toc: lsif-0-6-0-toc
 index: 2
 fullTitle: Language Server Index Format Specification - 0.6.0
+lspVersion: 3.17
 ---
 
 The 0.6.0 version of LSIF is currently under construction.

--- a/_specifications/lsif/0.6.0/specification.md
+++ b/_specifications/lsif/0.6.0/specification.md
@@ -50,15 +50,15 @@ Principal design goals:
 
 LSP requests that are good candidates to be supported in LSIF are:
 
-- [`textDocument/documentSymbol`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification#textDocument_documentSymbol)
-- [`textDocument/foldingRange`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification#textDocument_foldingRange)
-- [`textDocument/documentLink`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification#textDocument_documentLink)
-- [`textDocument/definition`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification#textDocument_definition)
-- [`textDocument/declaration`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification#textDocument_declaration)
-- [`textDocument/typeDefinition`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification#textDocument_typeDefinition)
-- [`textDocument/hover`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification#textDocument_hover)
-- [`textDocument/references`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification#textDocument_references)
-- [`textDocument/implementation`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification#textDocument_implementation)
+- `textDocument/documentSymbol`
+- `textDocument/foldingRange`
+- `textDocument/documentLink`
+- `textDocument/definition`
+- `textDocument/declaration`
+- `textDocument/typeDefinition`
+- `textDocument/hover`
+- `textDocument/references`
+- `textDocument/implementation`
 
 The corresponding LSP requests have one of the following two forms:
 


### PR DESCRIPTION
This is linked to #1411. In the spec documents, certain identifiers in the code blocks are converted into hyperlinks by some Javascript which runs in the user's browser. Currently, these links are resolved to a hard-coded base URL, namely the 3.17 spec. This means that links within the 3.16 document navigate to the 3.17 spec, and also means that future revisions will either need the hard-coded link to be changed, or risk pointing back to an older version.

There are two cases:
1. In the LSP specs the URLs should be left as fragments, and will therefore link to anchors in the same document
2. In the 'associated specs' (i.e. LSIF) the URLs should be resolved by the script to the corresponding LSP spec document

I thought it would be useful to allow for more 'associated specs' to be added in the future, and that they might need to refer to a specific version of the LSP spec.

Therefore I modified the JS code to pick up the LSP version from a key named `lspVersion` in the front matter of the page source. The information to get the (relative) base URL for a particular version is already in the repository, in `_data/specifications.yml`; I needed to add a `version` key to allow the correct one to be looked up.

* In the LSP spec documents, `lspVersion` is not defined and the links are left as fragment URLs to the same document (i.e. internal links)
* In the LSIF spec documents, `lspVersion` is defined and, via `_data/specifications.yml`, the URLs are converted to relative links to the appropriate spec version.

This happens when Jekyll builds the pages and there is no additional overhead when the user views the page.

Commit bbf793c implements this.
Commit 62077f2 is optional and just uses a JS Map to store the linking information instead of a bare object. 
Commit 58f8e0f is also optional and removes some absolute URL links from the LSIF page, because the auto-linking will now target the correct files.