### PR TITLE
Small improvement to the `CompletionOptions.triggerCharacters` docs

### DIFF
--- a/_specifications/lsp/3.17/language/completion.md
+++ b/_specifications/lsp/3.17/language/completion.md
@@ -182,16 +182,17 @@ _Server Capability_:
  */
 export interface CompletionOptions extends WorkDoneProgressOptions {
 	/**
-	 * Most tools trigger completion request automatically without explicitly
+	 * The additional characters, beyond the defaults provided by the client (typically
+	 * [a-zA-Z]), that should automatically trigger a completion request. For example
+	 * `.` in JavaScript represents the beginning of an object property or method and is
+	 * thus a good candidate for triggering a completion request.
+	 *
+	 * Most tools trigger a completion request automatically without explicitly
 	 * requesting it using a keyboard shortcut (e.g. Ctrl+Space). Typically they
 	 * do so when the user starts to type an identifier. For example if the user
 	 * types `c` in a JavaScript file code complete will automatically pop up
 	 * present `console` besides others as a completion item. Characters that
 	 * make up identifiers don't need to be listed here.
-	 *
-	 * If code complete should automatically be trigger on characters not being
-	 * valid inside an identifier (for example `.` in JavaScript) list them in
-	 * `triggerCharacters`.
 	 */
 	triggerCharacters?: string[];
 


### PR DESCRIPTION
I'm not sure if PRs are freely welcomed here? Excuse if they are not. Or let me know if there is a preferred means of contributing.

Small improvement to the `CompletionOptions.triggerCharacters` docs:
The existing docs leave the actual positive expression of the field to the end, and does so with somewhat obscure language. This improves the description by making the first paragraph positively summarize what is required. Whilst the second paragraph provides context around what isn't required.
