### PR TITLE
Fix typos in `RenameClientCapabilities` and `LinkedEditingRangeClientCapabilities` JSDocs

### DIFF
--- a/_specifications/lsp/3.17/language/linkedEditingRange.md
+++ b/_specifications/lsp/3.17/language/linkedEditingRange.md
@@ -14,7 +14,7 @@ _Client Capabilities_:
 ```typescript
 export interface LinkedEditingRangeClientCapabilities {
 	/**
-	 * Whether implementation supports dynamic registration.
+	 * Whether the implementation supports dynamic registration.
 	 * If this is set to `true` the client supports the new
 	 * `(TextDocumentRegistrationOptions & StaticRegistrationOptions)`
 	 * return value for the corresponding server capability as well.

--- a/_specifications/lsp/3.17/language/rename.md
+++ b/_specifications/lsp/3.17/language/rename.md
@@ -49,7 +49,7 @@ export interface RenameClientCapabilities {
 	prepareSupportDefaultBehavior?: PrepareSupportDefaultBehavior;
 
 	/**
-	 * Whether th client honors the change annotations in
+	 * Whether the client honors the change annotations in
 	 * text edits and resource operations returned via the
 	 * rename request's workspace edit by for example presenting
 	 * the workspace edit in the user interface and asking

--- a/_specifications/lsp/3.17/metaModel/metaModel.json
+++ b/_specifications/lsp/3.17/metaModel/metaModel.json
@@ -12339,7 +12339,7 @@
 						"name": "boolean"
 					},
 					"optional": true,
-					"documentation": "Whether implementation supports dynamic registration. If this is set to `true`\nthe client supports the new `(TextDocumentRegistrationOptions & StaticRegistrationOptions)`\nreturn value for the corresponding server capability as well."
+					"documentation": "Whether the implementation supports dynamic registration. If this is set to `true`\nthe client supports the new `(TextDocumentRegistrationOptions & StaticRegistrationOptions)`\nreturn value for the corresponding server capability as well."
 				}
 			],
 			"documentation": "Client capabilities for the linked editing range request.\n\n@since 3.16.0",

--- a/_specifications/lsp/3.18/language/linkedEditingRange.md
+++ b/_specifications/lsp/3.18/language/linkedEditingRange.md
@@ -14,7 +14,7 @@ _Client Capabilities_:
 ```typescript
 export interface LinkedEditingRangeClientCapabilities {
 	/**
-	 * Whether implementation supports dynamic registration.
+	 * Whether the implementation supports dynamic registration.
 	 * If this is set to `true` the client supports the new
 	 * `(TextDocumentRegistrationOptions & StaticRegistrationOptions)`
 	 * return value for the corresponding server capability as well.

--- a/_specifications/lsp/3.18/language/rename.md
+++ b/_specifications/lsp/3.18/language/rename.md
@@ -49,7 +49,7 @@ export interface RenameClientCapabilities {
 	prepareSupportDefaultBehavior?: PrepareSupportDefaultBehavior;
 
 	/**
-	 * Whether th client honors the change annotations in
+	 * Whether the client honors the change annotations in
 	 * text edits and resource operations returned via the
 	 * rename request's workspace edit by for example presenting
 	 * the workspace edit in the user interface and asking

--- a/_specifications/lsp/3.18/metaModel/metaModel.json
+++ b/_specifications/lsp/3.18/metaModel/metaModel.json
@@ -12339,7 +12339,7 @@
 						"name": "boolean"
 					},
 					"optional": true,
-					"documentation": "Whether implementation supports dynamic registration. If this is set to `true`\nthe client supports the new `(TextDocumentRegistrationOptions & StaticRegistrationOptions)`\nreturn value for the corresponding server capability as well."
+					"documentation": "Whether the implementation supports dynamic registration. If this is set to `true`\nthe client supports the new `(TextDocumentRegistrationOptions & StaticRegistrationOptions)`\nreturn value for the corresponding server capability as well."
 				}
 			],
 			"documentation": "Client capabilities for the linked editing range request.\n\n@since 3.16.0",

--- a/_specifications/specification-3-16.md
+++ b/_specifications/specification-3-16.md
@@ -7921,7 +7921,7 @@ _Client Capabilities_:
 ```typescript
 export interface LinkedEditingRangeClientCapabilities {
 	/**
-	 * Whether implementation supports dynamic registration.
+	 * Whether the implementation supports dynamic registration.
 	 * If this is set to `true` the client supports the new
 	 * `(TextDocumentRegistrationOptions & StaticRegistrationOptions)`
 	 * return value for the corresponding server capability as well.


### PR DESCRIPTION
What the title says.