### PR TITLE
fixes #1500: Type of DocumentLink.target should be URI instead of DocumentUri

### DIFF
--- a/_specifications/lsp/3.17/language/documentLink.md
+++ b/_specifications/lsp/3.17/language/documentLink.md
@@ -84,7 +84,7 @@ interface DocumentLink {
 	/**
 	 * The uri this link points to. If missing a resolve request is sent later.
 	 */
-	target?: DocumentUri;
+	target?: URI;
 
 	/**
 	 * The tooltip text when you hover over this link.

--- a/_specifications/lsp/3.17/types/position.md
+++ b/_specifications/lsp/3.17/types/position.md
@@ -43,7 +43,7 @@ export type PositionEncodingKind = string;
 export namespace PositionEncodingKind {
 
 	/**
-	 * Character offsets count UTF-8 code units.
+	 * Character offsets count UTF-8 code units (e.g bytes).
 	 */
 	export const UTF8: PositionEncodingKind = 'utf-8';
 

--- a/_specifications/lsp/3.18/language/documentLink.md
+++ b/_specifications/lsp/3.18/language/documentLink.md
@@ -84,7 +84,7 @@ interface DocumentLink {
 	/**
 	 * The uri this link points to. If missing a resolve request is sent later.
 	 */
-	target?: DocumentUri;
+	target?: URI;
 
 	/**
 	 * The tooltip text when you hover over this link.

--- a/_specifications/lsp/3.18/types/position.md
+++ b/_specifications/lsp/3.18/types/position.md
@@ -43,7 +43,7 @@ export type PositionEncodingKind = string;
 export namespace PositionEncodingKind {
 
 	/**
-	 * Character offsets count UTF-8 code units.
+	 * Character offsets count UTF-8 code units (e.g. bytes).
 	 */
 	export const UTF8: PositionEncodingKind = 'utf-8';
 


### PR DESCRIPTION
fixes #1500