### PR TITLE
Disallow JSON-RPC batch messages

### DIFF
--- a/_specifications/lsp/3.18/specification.md
+++ b/_specifications/lsp/3.18/specification.md
@@ -61,7 +61,9 @@ Content-Length: ...\r\n
 ```
 ### Base Protocol JSON structures
 
-The following TypeScript definitions describe the base [JSON-RPC protocol](http://www.jsonrpc.org/specification):
+The protocol uses request, response, and notification objects as specified in the [JSON-RPC protocol](http://www.jsonrpc.org/specification). The protocol currently does not support JSON-RPC batch messages; protocol clients and servers must not send JSON-RPC requests.
+
+The following TypeScript definitions describe the base JSON-RPC protocol:
 
 #### <a href="#baseTypes" name="baseTypes" class="anchor"> Base Types </a>
 


### PR DESCRIPTION
JSON-RPC 2.0 has a feature called "batch" where multiple requests and notifications can be grouped together into one message.

As an LSP server author, I have never seen an LSP client send these batch messages. I suspect that most LSP clients do not support receiving batch messages either, but I have not tried. The TypeScript type definitions in the LSP do not mention batch messages either.

Furthermore, disallowing batch messages has a few benefits:

* improves compatibility between servers and clients
* reduces the risk of LSP servers triggering bugs (including security bugs) in LSP clients, and vice versa
* reduces development time for conforming LSP servers and clients

Make the LSP match the status quo: Explicitly state in the language server protocol specification that batch messages are not allowed.