### PR TITLE
Add explaination about not returning too many code actions

### DIFF
--- a/_specifications/lsp/3.18/language/codeAction.md
+++ b/_specifications/lsp/3.18/language/codeAction.md
@@ -1,6 +1,8 @@
 #### <a href="#textDocument_codeAction" name="textDocument_codeAction" class="anchor">Code Action Request (:leftwards_arrow_with_hook:)</a>
 
-The code action request is sent from the client to the server to compute commands for a given text document and range. These commands are typically code fixes to either fix problems or to beautify/refactor code. The result of a `textDocument/codeAction` request is an array of `Command` literals which are typically presented in the user interface. To ensure that a server is useful in many clients the commands specified in a code actions should be handled by the server and not by the client (see `workspace/executeCommand` and `ServerCapabilities.executeCommandProvider`). If the client supports providing edits with a code action then that mode should be used.
+The code action request is sent from the client to the server to compute relevant commands for a given text document and range. These commands are typically code fixes to either fix problems or to beautify/refactor code. The result of a `textDocument/codeAction` request is an array of `Command` literals which are typically presented in the user interface. Servers should only return relevant commands and avoiding returning large lists of code actions, which can overwhelm the user and make it more difficult for them to find the code action they are after.
+
+To ensure that a server is useful in many clients the commands specified in a code actions should be handled by the server and not by the client (see `workspace/executeCommand` and `ServerCapabilities.executeCommandProvider`). If the client supports providing edits with a code action then that mode should be used.
 
 *Since version 3.16.0:* a client can offer a server to delay the computation of code action properties during a 'textDocument/codeAction' request:
 


### PR DESCRIPTION
Adding notes emphasizing that server should only return relevant code actions (and that returning too many code actions makes the entire response less relevant) This came up talking to pylance about their use of code actions 