### PR TITLE
Typo: i.e. not e.g.

### DIFF
--- a/_specifications/lsp/3.18/types/position.md
+++ b/_specifications/lsp/3.18/types/position.md
@@ -43,7 +43,7 @@ export type PositionEncodingKind = string;
 export namespace PositionEncodingKind {
 
 	/**
-	 * Character offsets count UTF-8 code units (e.g. bytes).
+	 * Character offsets count UTF-8 code units (i.e. bytes).
 	 */
 	export const UTF8: PositionEncodingKind = 'utf-8';
 


### PR DESCRIPTION
The intended meaning is "UTF-8 code units (that is, bytes)", but e.g. is "for example" so this reads as "UTF-8 code units (for example, bytes)". When I read this in the spec I was genuinely confused, does this flag mean _sometimes bytes and sometimes not_, because this is just an example? But then I realised it was just a grammatical error.

(I presume this isn't going to be accepted as a PR since the spec exists in multiple published versions and the next draft is probably somewhere else? Just sending this as a PR not an issue to make it clearer where the problem is.)