### PR TITLE
Added Pascal and Delphi language identifier

### DIFF
--- a/_specifications/lsp/3.18/types/textDocumentItem.md
+++ b/_specifications/lsp/3.18/types/textDocumentItem.md
@@ -42,6 +42,7 @@ C# | `csharp`
 CSS | `css`
 Diff | `diff`
 Dart | `dart`
+Delphi | `pascal`
 Dockerfile | `dockerfile`
 Elixir | `elixir`
 Erlang | `erlang`
@@ -63,6 +64,7 @@ Makefile | `makefile`
 Markdown | `markdown`
 Objective-C | `objective-c`
 Objective-C++ | `objective-cpp`
+Pascal | `pascal`
 Perl | `perl`
 Perl 6 | `perl6`
 PHP | `php`


### PR DESCRIPTION
This change adds both Delphi and generic Pascal languages to the list with `pascal` as the identifier for both.

Delphi has supported LSP since early 2020, and the Delphi IDE and language server use `pascal` as its identifier.

Other variants of Pascal, such as FreePascal, GNU Pascal etc likely would use the same. There is also an existing VSCode LSP plugin called OmniPascal which provides LSP for both Delphi and general Pascal and it too uses the same `pascal` identifier.