### PR TITLE
Update semanticTokens.md

### DIFF
--- a/_specifications/lsp/3.18/language/semanticTokens.md
+++ b/_specifications/lsp/3.18/language/semanticTokens.md
@@ -37,7 +37,7 @@ export enum SemanticTokenTypes {
 	string = 'string',
 	number = 'number',
 	regexp = 'regexp',
-	operator = 'operator'
+	operator = 'operator',
 	/**
 	 * @since 3.17.0
 	 */


### PR DESCRIPTION
Comma added in line after "operator = 'operator'" in order to correct typescript syntax error.