### PR TITLE
fix: make nav link hover more opaque

### DIFF
--- a/css/main.scss
+++ b/css/main.scss
@@ -464,15 +464,7 @@ pre[class=highlight] {
 }
 
 .navbar-dark .navbar-nav .nav-link:hover {
-    color: rgba(255,255,255,0.5);
-}
-
-.nav .nav-link {
-	color: #206bc6 !important;
-  }
-
-.nav .nav-link:hover {
-	color: #1034a8 !important;
+    color: rgba(255, 255, 255, 0.75);
 }
 
 code.highlighter-rouge a {
@@ -483,10 +475,6 @@ code.highlighter-rouge a {
 a h3, h2 a, h3 a, h4 a {
 	padding-top: 2px;
 	padding-bottom: 2px;
-}
-
-a:hover {
-	color: #1034a8;
 }
 
 .navbar-dark .navbar-nav .nav-link {


### PR DESCRIPTION
This is a debt-reducing PR that makes the nav links on hover more opaque so that they are easier to see.

After merging, we can also verify whether GitHub Pages deployments are working again.