### PR TITLE
Add glint

### DIFF
--- a/_implementors/servers.md
+++ b/_implementors/servers.md
@@ -74,6 +74,7 @@ index: 1
 | Gauge | [Gauge](https://github.com/getgauge) | [Gauge Language Server](https://github.com/getgauge/gauge/) | Go |
 | GDScript | [GodotEngine](https://github.com/godotengine) | [Godot](https://github.com/godotengine/godot) | C++ |
 | [Gleam](https://gleam.run/) | [Gleam](https://github.com/gleam-lang/gleam) | [gleam](https://github.com/gleam-lang/gleam) | Rust |
+| [Glimmer templates](https://typed-ember.gitbook.io/glint) | [Contributors](https://github.com/typed-ember/glint/graphs/contributors) | [Glint](https://github.com/typed-ember/glint) | TypeScript |
 | Gluon | [Gluon](https://github.com/gluon-lang/gluon) | [Gluon Language Server](https://github.com/gluon-lang/gluon_language-server) | Rust |
 | Go | [Go Team](https://github.com/golang/tools) | [gopls](https://github.com/golang/tools/tree/master/gopls) | Go |
 | Go | [Sourcegraph](https://sourcegraph.com/) | [sourcegraph-go](https://github.com/sourcegraph/go-langserver) | Go |


### PR DESCRIPTION
[Glint](https://typed-ember.gitbook.io/glint) is a set of tools to aid in developing code that uses the Glimmer VM for rendering, such as Ember.js and GlimmerX projects. The glint package includes two parts: glint cli and glint-language-server.