### PR TITLE
fix typo in metaModel.json

### DIFF
--- a/_specifications/lsp/3.18/metaModel/metaModel.json
+++ b/_specifications/lsp/3.18/metaModel/metaModel.json
@@ -1674,7 +1674,7 @@
 				"kind": "reference",
 				"name": "DocumentFormattingRegistrationOptions"
 			},
-			"documentation": "A request to to format a whole document."
+			"documentation": "A request to format a whole document."
 		},
 		{
 			"method": "textDocument/rangeFormatting",


### PR DESCRIPTION
typo fix . looks like this website not generate by a static tool ? main branch too old. so I fix in gh-page branch. If i am doing wrong branch please correct me thx :)