### PR TITLE
Fix wrong information in Language Server info table

### DIFF
--- a/_implementors/servers.md
+++ b/_implementors/servers.md
@@ -162,7 +162,7 @@ index: 1
 | ReasonML| [Jared Forsyth](https://github.com/jaredly) | [reason-language-server](https://github.com/jaredly/reason-language-server) | OCaml |
 | Red | [bitbegin](https://github.com/bitbegin) | [redlangserver](https://github.com/bitbegin/redlangserver) | Red |
 | [REL](https://github.com/sscit/rel) | [Stefan Schlichthärle](https://www.github.com/sscit) | [rel-ls](https://github.com/sscit/rel) | C++ |
-| [ReScript](https://rescript-lang.org) | [rescript-lang](https://github.com/rescript-lang) | [rescript-vscode](https://github.com/rescript-lang/rescript-vscode) | TypeScript |
+| [ReScript](https://rescript-lang.org) | [rescript-lang](https://github.com/rescript-lang) | [rescript-vscode](https://github.com/rescript-lang/rescript-vscode) | ReScript |
 | [IBM TSO/E **REXX**](https://www.ibm.com/docs/en/zos/2.4.0?topic=tsoe-zos-rexx-reference) | IBM |  [IBM Z Open Editor VS Code extension](https://marketplace.visualstudio.com/items?itemName=IBM.zopeneditor) | Java |
 | [Robot Framework](https://robotframework.org/) | [Daniel Biehl](https://github.com/d-biehl) | [RobotCode](https://github.com/d-biehl/robotcode) | Python |
 | [Robot Framework](https://robotframework.org/) | [Tomi Turtiainen](https://github.com/tomi) | [VSCode RF language server](https://github.com/tomi/vscode-rf-language-server) | TypeScript |


### PR DESCRIPTION
The ReScript language server was implemented mainly (>50%) in ReScript itself. A very significant portion seems to be implemented in OCaml, but I reason we very much mainly care about the most prominent language here.