### PR TITLE
Add Pyright to the list of language servers

### DIFF
--- a/_implementors/servers.md
+++ b/_implementors/servers.md
@@ -152,6 +152,7 @@ index: 1
 | PureScript | [Nicholas Wolverson](https://github.com/nwolverson) | [purescript-language-server](https://github.com/nwolverson/purescript-language-server) | PureScript |
 | Puppet| [Lingua Pupuli](https://github.com/lingua-pupuli) | [puppet language server](https://github.com/lingua-pupuli/puppet-editor-services) | Ruby |
 | Python| [Fabio Zadrozny](https://github.com/fabioz/) | [PyDev on VSCode](http://www.pydev.org/vscode/index.html) | Java, Python |
+| Python | MS | [Pyright](https://github.com/microsoft/pyright) | TypeScript |
 | Python| [Palantir Technologies](https://github.com/palantir) | [python-language-server](https://github.com/palantir/python-language-server) (unmaintained, use python-lsp-server instead) | Python |
 | Python| [Spyder IDE team and the community](https://github.com/python-lsp) | [python-lsp-server](https://github.com/python-lsp/python-lsp-server) | Python |
 | Python | MS | [python-language-server](https://github.com/Microsoft/python-language-server) (unmaintained, archived) | C# |


### PR DESCRIPTION
Given that the old Python language server has been [deprecated](https://github.com/microsoft/language-server-protocol/pull/1820), it might be worth pointing users to a newer alternative.

[Pyright](https://github.com/microsoft/pyright) is an open-source type checker that [can function as a standalone language server](https://github.com/microsoft/pyright/pull/810).

> Note: This is not to be confused with the [Pylance language server](https://github.com/microsoft/pylance-release), which also uses Pyright, but is closed-source and may only be used in official VSCode builds.