### PR TITLE
update tools.md - add jetbrains fleet

### DIFF
--- a/_implementors/tools.md
+++ b/_implementors/tools.md
@@ -31,6 +31,7 @@ index: 2
 | [Helix Editor](https://helix-editor.com/) | [Blaž Hrastnik](https://github.com/archseer) | [helix](https://github.com/helix-editor/helix) |
 | [IntelliJ IDEA](https://www.jetbrains.com/idea/) | [JetBrains](https://www.jetbrains.com) | Proprietary |
 | [JCIDE](https://www.javacardos.com/tools) | [Javacardos](https://www.javacardos.com) | [JCIDE](https://www.javacardos.com/javacardforum/viewtopic.php?f=5&t=2108&p=6175#p6175) |
+| [JetBrains Fleet](https://www.jetbrains.com/fleet/) | [JetBrains](https://www.jetbrains.com) | Proprietary |
 | [JupyterLab](https://github.com/jupyterlab/jupyterlab) | [krassowski](https://github.com/krassowski) | [jupyterlab-lsp](https://github.com/jupyter-lsp/jupyterlab-lsp) |
 | [Kakoune](http://kakoune.org/) | [ul](https://github.com/ul) | [kak-lsp](https://github.com/ul/kak-lsp) |
 | [Kate](https://kate-editor.org) | [Kate Team](https://kate-editor.org) | [kate](https://invent.kde.org/kde/kate) |


### PR DESCRIPTION
The new JetBrains ide called  "Fleet" uses LSPs for almost all supported languages.
Except Java and maybe kotlin. (an headless intellij is used instead)

![architecture-diagram_dark](https://github.com/microsoft/language-server-protocol/assets/13398285/7083e48b-5389-4588-b919-16af34f1be50)



Source: https://www.jetbrains.com/help/fleet/architecture-overview.html 