### PR TITLE
Fix NotebookDocumentSync example

### DIFF
--- a/_specifications/lsp/3.17/notebookDocument/notebook.md
+++ b/_specifications/lsp/3.17/notebookDocument/notebook.md
@@ -241,10 +241,12 @@ To synchronize the whole notebook document a server provides a `notebookDocument
 ```typescript
 {
 	notebookDocumentSync: {
-		notebookSelector: {
-			notebook: { scheme: 'file', notebookType: 'jupyter-notebook' },
-			cells: [{ language: 'python' }]
-		}
+		notebookSelector: [
+			{
+				notebook: { scheme: 'file', notebookType: 'jupyter-notebook' },
+				cells: [{ language: 'python' }]
+			}
+		]
 	}
 }
 ```

--- a/_specifications/lsp/3.18/notebookDocument/notebook.md
+++ b/_specifications/lsp/3.18/notebookDocument/notebook.md
@@ -241,10 +241,12 @@ To synchronize the whole notebook document a server provides a `notebookDocument
 ```typescript
 {
 	notebookDocumentSync: {
-		notebookSelector: {
-			notebook: { scheme: 'file', notebookType: 'jupyter-notebook' },
-			cells: [{ language: 'python' }]
-		}
+		notebookSelector: [
+			{
+				notebook: { scheme: 'file', notebookType: 'jupyter-notebook' },
+				cells: [{ language: 'python' }]
+			}
+		]
 	}
 }
 ```


### PR DESCRIPTION
The given example does not follow the specification just below.
The `NotebookSelector` field is an array type.