### PR TITLE
align image paths in lsif/overview.md

### DIFF
--- a/_overviews/lsif/overview.md
+++ b/_overviews/lsif/overview.md
@@ -31,7 +31,7 @@ Hovering over `bar()` shows the following hover information in Visual Studio Cod
 
 ---
 
-![Hover over Bar](../img/hover.png)
+![Hover over Bar](../lsif/img/hover.png)
 
 ---
 
@@ -95,7 +95,7 @@ For the hover example, the emitted LSIF graph data looks as follows:
 
 The corresponding graph looks like this:
 
-![LSIF graph for a hover](../img/hoverResult.png)
+![LSIF graph for a hover](../lsif/img/hoverResult.png)
 
 The LSP also supports requests that only take a document as a parameter (they are not position based). Example requests that are useful for code comprehension are for a list of all document symbols or to compute all folding ranges. These requests are modeled in LSIF in the form `[request, document]` -> result.
 
@@ -118,7 +118,7 @@ The folding range result for the document containing above function `bar` is emi
 { id: 3, type: "edge", label: "textDocument/foldingRange", outV: 1, inV: 2 }
 ```
 
-![LSIF graph for a folding range result](../img/foldingRange.png)
+![LSIF graph for a folding range result](../lsif/img/foldingRange.png)
 
 These are only two examples of LSP requests supported by the LSIF. The current version of the [LSIF specification](https://github.com/Microsoft/language-server-protocol/blob/master/indexFormat/specification.md) also supports document symbols, document links, Go to Definition, Go to Declaration, Go to Type Definition, Find All References, and Go to Implementation.
 


### PR DESCRIPTION
### align image paths in `lsif/overview.md`
- update non-functional image links within `lsif/overview.md`.
- align paths for `hover.png`, `hoverResult.png`, `foldingRange.png`.

Compliance:
This pull request adheres to Microsoft's Open Source Code of Conduct.