### PR TITLE
Add monaco-languageserver-types to utilities

### DIFF
--- a/_implementors/utilities.md
+++ b/_implementors/utilities.md
@@ -8,7 +8,8 @@ index: 4
 
 *If you are missing a utility please create a pull request in GitHub against this markdown [document](https://github.com/Microsoft/language-server-protocol/blob/gh-pages/_implementors/utilities.md)*
 
-| Tool                                               | Maintainer                                 | Repository                                       | Implementation Language |
-|----------------------------------------------------|--------------------------------------------|--------------------------------------------------|-------------------------|
-| [lasponya](https://www.npmjs.com/package/lasponya) | [Tamás Balog](https://github.com/picimako) | [Lasponya](https://github.com/picimako/lasponya) | TypeScript              |
+| Tool                                                                                     | Maintainer                                       | Repository                                                                                 | Implementation Language |
+|------------------------------------------------------------------------------------------|--------------------------------------------------|--------------------------------------------------------------------------------------------|-------------------------|
+| [lasponya](https://www.npmjs.com/package/lasponya)                                       | [Tamás Balog](https://github.com/picimako)       | [Lasponya](https://github.com/picimako/lasponya)                                           | TypeScript              |
+| [monaco-languageserver-types](https://www.npmjs.com/package/monaco-languageserver-types) | [Remco Haszing](https://github.com/remcohaszing) | [monaco-languageserver-types](https://github.com/remcohaszing/monaco-languageserver-types) | TypeScript              |
 {: .table .table-bordered .table-responsive}


### PR DESCRIPTION
This package is useful for integrating LSP compliant language services into Monaco editor.