### PR TITLE
Mark Range in TextDocumentContentChangeEvent as optional

### DIFF
--- a/_specifications/lsp/3.18/textDocument/didChange.md
+++ b/_specifications/lsp/3.18/textDocument/didChange.md
@@ -71,7 +71,7 @@ export type TextDocumentContentChangeEvent = {
 	/**
 	 * The range of the document that changed.
 	 */
-	range: Range;
+	range?: Range;
 
 	/**
 	 * The optional length of the range that got replaced.


### PR DESCRIPTION
Fixes #1870 