### PR TITLE
Add Instruction and Register variants to CompletionItemKind

### DIFF
--- a/_specifications/lsp/3.18/language/completion.md
+++ b/_specifications/lsp/3.18/language/completion.md
@@ -747,9 +747,11 @@ export namespace CompletionItemKind {
 	export const Event = 23;
 	export const Operator = 24;
 	export const TypeParameter = 25;
+	export const Instruction = 26;
+	export const Register = 27;
 }
 
-export type CompletionItemKind = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 15 | 16 | 17 | 18 | 19 | 20 | 21 | 22 | 23 | 24 | 25;
+export type CompletionItemKind = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 15 | 16 | 17 | 18 | 19 | 20 | 21 | 22 | 23 | 24 | 25 | 26 | 27;
 ```
 * partial result: `CompletionItem[]` or `CompletionList` followed by `CompletionItem[]`. If the first provided result item is of type `CompletionList` subsequent partial results of `CompletionItem[]` add to the `items` property of the `CompletionList`.
 * error: code and message set in case an exception happens during the completion request.


### PR DESCRIPTION
Would it be possible to add `Instruction` and `Register` variants to `CompletionItemKind` to better support LSPs targeting assembly languages? 