### PR TITLE
Fixes #1873: Can a client use window/workDoneProgress/cancel to cancel a progress token provided by the client?

### DIFF
--- a/_specifications/base/0.9/specification.md
+++ b/_specifications/base/0.9/specification.md
@@ -620,7 +620,8 @@ A server uses the `workDoneToken` to report progress for the specific `build/dep
 }
 ```
 
-The token received via the `workDoneToken` property in a request's param literal is only valid as long as the request has not send a response back.
+The token received via the `workDoneToken` property in a request's param literal is only valid as long as the request has not send a response back. Canceling work done progress is done by simply
+canceling the corresponding request.
 
 There is no specific client capability signaling whether a client will send a progress token per request. The reason for this is that this is in many clients not a static aspect and might even change for every request instance for the same request type. So the capability is signal on every request instance by the presence of a `workDoneToken` property.
 

--- a/_specifications/lsp/3.17/types/workDoneProgress.md
+++ b/_specifications/lsp/3.17/types/workDoneProgress.md
@@ -162,7 +162,8 @@ A server uses the `workDoneToken` to report progress for the specific `textDocum
 }
 ```
 
-The token received via the `workDoneToken` property in a request's param literal is only valid as long as the request has not send a response back.
+The token received via the `workDoneToken` property in a request's param literal is only valid as long as the request has not send a response back. Canceling work done progress is done by simply
+canceling the corresponding request.
 
 There is no specific client capability signaling whether a client will send a progress token per request. The reason for this is that this is in many clients not a static aspect and might even change for every request instance for the same request type. So the capability is signal on every request instance by the presence of a `workDoneToken` property.
 

--- a/_specifications/lsp/3.18/types/workDoneProgress.md
+++ b/_specifications/lsp/3.18/types/workDoneProgress.md
@@ -162,7 +162,8 @@ A server uses the `workDoneToken` to report progress for the specific `textDocum
 }
 ```
 
-The token received via the `workDoneToken` property in a request's param literal is only valid as long as the request has not send a response back.
+The token received via the `workDoneToken` property in a request's param literal is only valid as long as the request has not send a response back. Canceling work done progress is done by simply
+canceling the corresponding request.
 
 There is no specific client capability signaling whether a client will send a progress token per request. The reason for this is that this is in many clients not a static aspect and might even change for every request instance for the same request type. So the capability is signal on every request instance by the presence of a `workDoneToken` property.
 


### PR DESCRIPTION
Fixes #1873