### PR TITLE
Add string value definition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ npm-debug.log
 _site/
 .bundle/
 vendor/
+.jekyll-metadata

--- a/_data/linkableTypes.yml
+++ b/_data/linkableTypes.yml
@@ -898,3 +898,5 @@
     link: '#inlineCompletionList'
   - type: 'InlineCompletionItem'
     link: '#inlineCompletionItem'
+  - type: 'StringValue'
+    link: '#stringValue'

--- a/_data/specification-3-18-toc.yml
+++ b/_data/specification-3-18-toc.yml
@@ -56,6 +56,8 @@
       anchor: textDocumentPositionParams
     - title: Document Filter
       anchor: documentFilter
+    - title: String Value
+      anchor: stringValue
     - title: Text Edit
       anchor: textEdit
     - title: Text Edit Array

--- a/_specifications/lsp/3.18/language/inlineCompletion.md
+++ b/_specifications/lsp/3.18/language/inlineCompletion.md
@@ -203,7 +203,7 @@ export interface InlineCompletionItem {
 	 * The text to replace the range with. Must be set.
 	 * Is used both for the preview and the accept operation.
 	 */
-	insertText: string;
+	insertText: string | StringValue;
 
 	/**
 	 * A text that is used to decide if this inline completion should be

--- a/_specifications/lsp/3.18/specification.md
+++ b/_specifications/lsp/3.18/specification.md
@@ -451,6 +451,7 @@ There are quite some JSON structures that are shared between different requests 
 {% include_relative types/textDocumentPositionParams.md %}
 {% include_relative types/documentFilter.md %}
 
+{% include_relative types/stringValue.md %}
 {% include_relative types/textEdit.md %}
 {% include_relative types/textEditArray.md %}
 {% include_relative types/textDocumentEdit.md %}

--- a/_specifications/lsp/3.18/types/stringValue.md
+++ b/_specifications/lsp/3.18/types/stringValue.md
@@ -1,0 +1,28 @@
+#### <a href="#stringValue" name="stringValue" class="anchor"> String Value </a>
+
+Template strings for inserting text and controlling the editor cursor upon insertion.
+
+```typescript
+/**
+ * A string value used as a snippet is a template which allows to insert text
+ * and to control the editor cursor when insertion happens.
+ *
+ * A snippet can define tab stops and placeholders with `$1`, `$2`
+ * and `${3:foo}`. `$0` defines the final tab stop, it defaults to
+ * the end of the snippet. Variables are defined with `$name` and
+ * `${name:default value}`.
+ * 
+ * @since 3.18.0
+ */
+export interface StringValue {
+	/**
+	 * The kind of string value.
+	 */
+	kind: 'snippet';
+
+	/**
+	 * The snippet string.
+	 */
+	value: string;
+}
+```


### PR DESCRIPTION
Adds the definition of `StringValue`, which is currently used in the metamodel by inline completions.