### PR TITLE
Remove insertTextFormat from InlineCompletionItem

### DIFF
--- a/_specifications/lsp/3.18/language/inlineCompletion.md
+++ b/_specifications/lsp/3.18/language/inlineCompletion.md
@@ -229,12 +229,6 @@ export interface InlineCompletionItem {
 	 * completion.
 	 */
 	command?: Command;
-
-	/**
-	 * The format of the insert text. The format applies to the `insertText`.
-	 * If omitted, defaults to `InsertTextFormat.PlainText`.
-	 */
-	insertTextFormat?: InsertTextFormat;
 }
 ```
 


### PR DESCRIPTION
See https://github.com/microsoft/language-server-protocol/pull/1893#issuecomment-1921961626 for why I think we should remove this.