### PR TITLE
Removed deprecated Rust Language Server (RLS)

### DIFF
--- a/_implementors/servers.md
+++ b/_implementors/servers.md
@@ -189,7 +189,6 @@ index: 1
 | Ruby | [Rafał Łasocha](https://github.com/swistak35) | [orbacle](https://github.com/swistak35/orbacle) | Ruby |
 | [Ruby](https://www.ruby-lang.org/en/) | [Kurt Werle](https://github.com/kwerle/) | [ruby_language_server](https://github.com/kwerle/ruby_language_server) | Ruby |
 | Ruby | [Shopify](https://github.com/Shopify) | [Ruby LSP](https://github.com/Shopify/ruby-lsp) | Ruby |
-| Rust | [Jonathan Turner](https://github.com/jonathandturner) | [Rust Language Server](https://github.com/rust-lang-nursery/rls) | Rust |
 | Rust | [Aleksey Kladov](https://github.com/matklad) | [Rust Analyzer](https://github.com/rust-analyzer/rust-analyzer) | Rust |
 | Scala | [Iulian Dragos](https://github.com/dragos) | [dragos-vscode-scala](https://github.com/dragos/dragos-vscode-scala) | Scala |
 | Scala | [Scalameta](https://github.com/scalameta) | [Metals](https://github.com/scalameta/metals) | Scala |


### PR DESCRIPTION
The Rust Language Server (RLS) was deprecated in Dec. 2022. [link](https://github.com/rust-lang/rls)

This pull request removes it from the list of available servers

