### PR TITLE
Add markup diagnostic message clarification

### DIFF
--- a/_specifications/lsp/3.18/language/codeAction.md
+++ b/_specifications/lsp/3.18/language/codeAction.md
@@ -364,6 +364,8 @@ export interface CodeActionContext {
 	 * 
 	 * Note that the client should check the `textDocument.diagnostic.markupMessageSupport`
 	 * server capability before sending diagnostics with markup messages to a server.
+	 * Diagnostics with markup messages should be excluded for servers that don't support
+	 * them.
 	 */
 	diagnostics: Diagnostic[];
 


### PR DESCRIPTION
Follow-up of https://github.com/microsoft/language-server-protocol/pull/1905.

As commented [here](https://github.com/microsoft/language-server-protocol/pull/1905#issuecomment-2011658286), the protocol should be clear about what to do when a diagnostic has a markup message and these are being sent in the code action context to a server that doesn't support them.