### PR TITLE
docs: add biome to lsp servers

### DIFF
--- a/_implementors/servers.md
+++ b/_implementors/servers.md
@@ -114,6 +114,7 @@ index: 1
 | JavaScript Flow| [Facebook, Inc.](https://flow.org/) | [flow](https://github.com/facebook/flow) | OCaml, JavaScript |
 | JavaScript Flow| [flowtype](https://github.com/flowtype/) | [flow-language-server](https://github.com/flowtype/flow-language-server)(deprecated) | JavaScript, Flow |
 | JavaScript-Typescript | [Sourcegraph](https://sourcegraph.com/) | [javascript-typescript](https://github.com/sourcegraph/javascript-typescript-langserver) | TypeScript |
+| JavaScript-Typescript | [Biome](https://github.com/biomejs) | [biome_lsp](https://github.com/biomejs/biome/tree/main/crates/biome_lsp) | Rust |
 | JSON | MS | [vscode-json-languageserver](https://www.npmjs.com/package/vscode-json-languageserver) | TypeScript |
 | [Jsonnet](https://jsonnet.org/) | [Grafana Labs](https://grafana.com/) | [jsonnet-language-server](https://github.com/grafana/jsonnet-language-server) | Go |
 | [Julia](http://julialang.org/) | [Contributors](https://github.com/JuliaEditorSupport/LanguageServer.jl/graphs/contributors) | [Julia language server](https://github.com/JuliaEditorSupport/LanguageServer.jl) | Julia |


### PR DESCRIPTION
This PR adds Biome (biome_lsp) as language server implementations.