### PR TITLE
add SAP CDS server

### DIFF
--- a/_implementors/servers.md
+++ b/_implementors/servers.md
@@ -42,6 +42,7 @@ index: 1
 | [C++/clang](https://clangd.llvm.org/)| [LLVM Project](https://llvm.org/) | [clangd](https://github.com/llvm/llvm-project/tree/main/clang-tools-extra/clangd) | C++ |
 | C/C++/Objective-C | [Jacob Dufault](https://github.com/jacobdufault), [MaskRay](https://github.com/MaskRay), [topisani](https://github.com/topisani) | [cquery](https://github.com/jacobdufault/cquery) | C++ |
 | C/C++/Objective-C | [MaskRay](https://github.com/MaskRay) | [ccls](https://github.com/MaskRay/ccls) | C++ |
+| [CDS](https://cap.cloud.sap/docs/cds/) | [SAP](https://www.sap.com/) | [@sap/cds-lsp](https://www.npmjs.com/package/@sap/cds-lsp) (no code repository available) | JavaScript |
 | CSS/LESS/SASS | MS | [vscode-css-languageserver](https://github.com/Microsoft/vscode/tree/master/extensions/css-language-features/server) | TypeScript |
 | [Ceylon](https://ceylon-lang.org/) | [John Vasileff](https://github.com/jvasileff) | [vscode-ceylon](https://github.com/jvasileff/vscode-ceylon) | Ceylon |
 | [Clarity](https://docs.stacks.co/docs/write-smart-contracts/) | [Hiro](https://hiro.so) | [clarity-lsp](https://github.com/hirosystems/clarity-lsp) | TypeScript |


### PR DESCRIPTION
The Language Server is available only as an NPM package; there is no source code repository. In addition, the package is provided under the terms of the [SAP Developer License Agreement.](https://tools.hana.ondemand.com/developer-license-3_1.txt).  
If it should be described differently, I can correct it.