### PR TITLE
fix: use visibility instead of display

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -24,7 +24,7 @@
             </div>
             <div class="col-sm-4">
                 <ul class="links">
-                    <li style="display: none;" >
+                    <li style="visibility: hidden;" >
                         <a id="footer-cookie-link" style="cursor: pointer; padding-right:20px" onclick="manageConsent()"
                             aria-label="Manage cookies">Manage cookies</a>
                     </li>

--- a/js/page.js
+++ b/js/page.js
@@ -39,7 +39,7 @@ $(function () {
 
   const cookieManager = document.querySelector('#footer-cookie-link');
   if (consentRequired() && cookieManager && cookieManager.parentElement) {
-    cookieManager.parentElement.style.display = '';
+    cookieManager.parentElement.style.visibility = 'visible';
   }
 
   // initialize consent


### PR DESCRIPTION
TIL that I can use the visibility keyword to keep the spacing of an element while hiding it.

With this PR, users who don't see the Manage Cookies link won't see the MS icon unnecessarily shifted to the left.