### PR TITLE
fix: align copyright year and image

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -35,7 +35,7 @@
                                     <source srcset="{{site.baseurl}}/img/microsoft-logo.png" media="(prefers-color-scheme: dark)"></source>
                                     <img src="{{site.baseurl}}/img/microsoft-logo-inverted.png" height="20" alt="Microsoft">
                                 </picture>
-                            </a><br>
+                            </a>
                             <span>© 2024 Microsoft</span>
                         </div>
                     </li>

--- a/css/main.scss
+++ b/css/main.scss
@@ -384,10 +384,10 @@ pre[class=highlight] {
 
 	img {
 		width: 100px;
+	}
 
-		@media (min-width: 576px) {
-			float: right;
-		}
+	a#footer-microsoft-link {
+		display: block;
 	}
 
 	ul {


### PR DESCRIPTION
It turns out the DAP website had this change but the LSP one didn't.
Ref https://github.com/microsoft/debug-adapter-protocol/commit/c156d43c9f5de2d4dece5121ecb1bd71ee77e18b#diff-13a60aef4a70b83506a6cc092790f9c995a38d3d015ccf3ac5bcf2940a1a7477R373