### PR TITLE
Add LanguageServer::Protocol in Ruby to SDKs

### DIFF
--- a/_implementors/sdks.md
+++ b/_implementors/sdks.md
@@ -27,6 +27,7 @@ index: 3
 | Python | [Open Law Library](http://www.openlawlib.org/) | [pygls](https://github.com/openlawlibrary/pygls)|
 | Python | [Yeger](https://github.com/yeger00) | [pylspclient](https://github.com/yeger00/pylspclient)|
 | Python | [Microsoft](https://github.com/microsoft) | [multilspy](https://github.com/microsoft/monitors4codegen#4-multilspy)|
+| Ruby | [Fumiaki MATSUSHIMA](https://github.com/mtsmfm) | [LanguageServer::Protocol](https://github.com/mtsmfm/language_server-protocol-ruby) |
 | Rust | [Bruno Medeiros](https://github.com/bruno-medeiros) | [RustLSP](https://github.com/RustDT/RustLSP)|
 | Rust | Bruno Medeiros and Markus Westerlind | [lsp-types](https://github.com/gluon-lang/lsp-types)
 | Rust | [Eyal Kalderon](https://github.com/ebkalderon) | [tower-lsp](https://github.com/ebkalderon/tower-lsp)


### PR DESCRIPTION
The LanguageServer::Protocol gem is used by famous LSP implementations.
See https://rubygems.org/gems/language_server-protocol/reverse_dependencies