### PR TITLE
Add LPC to servers.md

### DIFF
--- a/_implementors/servers.md
+++ b/_implementors/servers.md
@@ -129,6 +129,7 @@ index: 1
 | [LanguageTool](https://languagetool.org/)| [Julian Valentin](https://github.com/valentjn) | [ltex-ls](https://github.com/valentjn/ltex-ls) | Kotlin |
 | [LaTeX](https://www.latex-project.org/)| [Eric Förster](https://github.com/efoerster) | [texlab](https://github.com/efoerster/texlab) |
 | [Lox](https://craftinginterpreters.com/appendix-i.html) | [Ajeet D'Souza](https://github.com/ajeetdsouza) | [loxcraft](https://github.com/ajeetdsouza/loxcraft) | Rust |
+| LPC | [John Chmura](https://github.com/jlchmura/) | [lpc-language-server](https://github.com/jlchmura/lpc-language-server) | TypeScript |
 | [Lua](http://www.lua.org/)| [Kyle McLamb](https://github.com/Alloyed) | [lua-lsp](https://github.com/Alloyed/lua-lsp) | Lua |
 | [Lua](http://www.lua.org/)| [最萌小汐](https://github.com/sumneko) | [lua-language-server](https://github.com/sumneko/lua-language-server) | Lua |
 | [Lua](http://www.lua.org/)| [Tencent](https://github.com/Tencent/LuaHelper) | [LuaHelper](https://github.com/Tencent/LuaHelper) | Go |


### PR DESCRIPTION
Adding LPC to the list of language servers. LPC is a language used in [LPMuds](https://en.wikipedia.org/wiki/LPMud).