### PR TITLE
Recommend a default diagnostic severity for clients

### DIFF
--- a/_specifications/lsp/3.17/types/diagnostic.md
+++ b/_specifications/lsp/3.17/types/diagnostic.md
@@ -12,7 +12,8 @@ export interface Diagnostic {
 	/**
 	 * The diagnostic's severity. To avoid interpretation mismatches when a
 	 * server is used with different clients it is highly recommended that
-	 * servers always provide a severity value.
+	 * servers always provide a severity value. If omitted, it’s recommended
+	 * for the client to interpret it as an Error severity.
 	 */
 	severity?: DiagnosticSeverity;
 

--- a/_specifications/lsp/3.18/types/diagnostic.md
+++ b/_specifications/lsp/3.18/types/diagnostic.md
@@ -16,7 +16,8 @@ export interface Diagnostic {
 	/**
 	 * The diagnostic's severity. To avoid interpretation mismatches when a
 	 * server is used with different clients it is highly recommended that
-	 * servers always provide a severity value.
+	 * servers always provide a severity value. If omitted, it’s recommended
+	 * for the client to interpret it as an Error severity.
 	 */
 	severity?: DiagnosticSeverity;
 


### PR DESCRIPTION
Add a recommendation for clients to interpret diagnostics without a severity as an error.

In #1958 I proposed some recommendations. In #1973 the recommandation was added to always specify the diagnostic severity. This change adds a recommendation for clients how to interpret diagnostics without a severity.