### PR TITLE
Add PartiQL to servers.md

### DIFF
--- a/_implementors/servers.md
+++ b/_implementors/servers.md
@@ -155,6 +155,7 @@ index: 1
 | [OpenAPI](https://www.openapis.org/) | [AML](https://a.ml/) | [AML Language Server](https://github.com/aml-org/als) | ScalaJS |
 | [openVALIDATION](http://openvalidation.io/) | [openVALIDATION](https://github.com/openvalidation) | [ov-language-server](https://github.com/openvalidation/ov-language-server) | TypeScript
 | [Papyrus](https://www.creationkit.com/fallout4/index.php?title=Category:Papyrus) | [Joel Day](https://github.com/joelday) | [papyrus-lang](https://github.com/joelday/papyrus-lang) | C# |
+| [PartiQL](https://partiql.org/) | [AWS](https://github.com/aws/language-servers) | [aws-lsp-partiql](https://github.com/aws/language-servers/tree/main/server/aws-lsp-partiql) | TypeScript |
 | Perl | GRICHTER | [Perl::LanguageServer](https://metacpan.org/pod/Perl::LanguageServer) | Perl |
 | Perl | [Marc Reisner](https://github.com/FractalBoy) | [PLS](https://github.com/FractalBoy/perl-language-server)| Perl |
 | Perl | [Brian Scannell](https://github.com/bscan) | [Perl Navigator](https://github.com/bscan/PerlNavigator)| Perl |


### PR DESCRIPTION
Added `aws-lsp-partiql`, a language server for the `SQL++` language `PartiQL`, maintained by [@aws](https://github.com/aws), to servers.md.