### PR TITLE
Add new CodeLens capability to metamodel

### DIFF
--- a/_specifications/lsp/3.18/metaModel/metaModel.json
+++ b/_specifications/lsp/3.18/metaModel/metaModel.json
@@ -12323,6 +12323,16 @@
 					},
 					"optional": true,
 					"documentation": "Whether code lens supports dynamic registration."
+				},
+				{
+					"name": "resolveSupport",
+					"type": {
+						"kind": "reference",
+						"name": "ClientCodeLensResolveOptions"
+					},
+					"optional": true,
+					"documentation": "Whether the client supports resolving additional code lens properties via a separate `codeLens/resolve` request.",
+					"since": "3.18.0"
 				}
 			],
 			"documentation": "The client capabilities  of a {@link CodeLensRequest}."
@@ -14915,6 +14925,28 @@
 			},
 			"documentation": "The glob pattern to watch relative to the base path. Glob patterns can have the following syntax:\n- `*` to match one or more characters in a path segment\n- `?` to match on one character in a path segment\n- `**` to match any number of path segments, including none\n- `{}` to group conditions (e.g. `**​/*.{ts,js}` matches all TypeScript and JavaScript files)\n- `[]` to declare a range of characters to match in a path segment (e.g., `example.[0-9]` to match on `example.0`, `example.1`, …)\n- `[!...]` to negate a range of characters to match in a path segment (e.g., `example.[!0-9]` to match on `example.a`, `example.b`, but not `example.0`)\n\n@since 3.17.0",
 			"since": "3.17.0"
+		},
+		{
+			"name": "ClientCodeLensResolveOptions",
+			"type": {
+				"kind": "literal",
+				"value": {
+					"properties": [
+						{
+							"name": "properties",
+							"type": {
+								"kind": "array",
+								"element": {
+									"kind": "base",
+									"name": "string"
+									}
+							},
+							"documentation": "The properties that a client can resolve lazily."
+						}
+					]
+				}
+			},
+			"since": "3.18.0"
 		}
 	]
 }


### PR DESCRIPTION
Editors (like [Neovim](https://github.com/neovim/neovim/blob/7d24c4d6b0413cd5af8d0579f0a9a694db7f775e/scripts/gen_lsp.lua)) rely on the metamodel accurately reflecting the current state of the LSP.

#1979 introduced a new capability without updating the metamodel. This PR fixes that.