### PR TITLE
Ensure document state synchronization before client requests

### DIFF
--- a/_specifications/lsp/3.17/textDocument/didChange.md
+++ b/_specifications/lsp/3.17/textDocument/didChange.md
@@ -4,6 +4,14 @@ The document change notification is sent from the client to the server to signal
 
 Before requesting information from the server (e.g., `textDocument/completion` or `textDocument/signatureHelp`), the client must ensure that the document's state is synchronized with the server to guarantee reliable results.
 
+The following example shows how the client should synchronize the state when the user has continuous input, assuming user input triggered `textDocument/completion`:
+
+| Document Version | User Input          | Client Behavior                                 | Request                   |
+| ---------------- | ------------------- | ----------------------------------------------- | ------------------------- |
+| 5                | document change one | sync document `v5` to the server                | `textDocument/didChange`  |
+| 5                | -                   | request from the server, based on document `v5` | `textDocument/completion` |
+| 6                | document change two | sync document `v6` to the server                | `textDocument/didChange`  |
+
 _Client Capability_:
 See general synchronization [client capabilities](#textDocument_synchronization_cc).
 

--- a/_specifications/lsp/3.17/textDocument/didChange.md
+++ b/_specifications/lsp/3.17/textDocument/didChange.md
@@ -2,6 +2,8 @@
 
 The document change notification is sent from the client to the server to signal changes to a text document. Before a client can change a text document it must claim ownership of its content using the `textDocument/didOpen` notification. In 2.0 the shape of the params has changed to include proper version numbers.
 
+Before requesting information from the server (e.g., `textDocument/completion` or `textDocument/signatureHelp`), the client must ensure that the document's state is synchronized with the server to guarantee reliable results.
+
 _Client Capability_:
 See general synchronization [client capabilities](#textDocument_synchronization_cc).
 

--- a/_specifications/lsp/3.18/language/signatureHelp.md
+++ b/_specifications/lsp/3.18/language/signatureHelp.md
@@ -2,8 +2,6 @@
 
 The signature help request is sent from the client to the server to request signature information at a given cursor position.
 
-If a user types and the client decides to ask for signature help, `textDocument/didChange` event must be delivered to the server before the signature help request is sent.
-
 _Client Capability_:
 * property name (optional): `textDocument.signatureHelp`
 * property type: `SignatureHelpClientCapabilities` defined as follows:

--- a/_specifications/lsp/3.18/language/signatureHelp.md
+++ b/_specifications/lsp/3.18/language/signatureHelp.md
@@ -2,6 +2,8 @@
 
 The signature help request is sent from the client to the server to request signature information at a given cursor position.
 
+If a user types and the client decides to ask for signature help, `textDocument/didChange` event must be delivered to the server before the signature help request is sent.
+
 _Client Capability_:
 * property name (optional): `textDocument.signatureHelp`
 * property type: `SignatureHelpClientCapabilities` defined as follows:

--- a/_specifications/lsp/3.18/textDocument/didChange.md
+++ b/_specifications/lsp/3.18/textDocument/didChange.md
@@ -4,6 +4,14 @@ The document change notification is sent from the client to the server to signal
 
 Before requesting information from the server (e.g., `textDocument/completion` or `textDocument/signatureHelp`), the client must ensure that the document's state is synchronized with the server to guarantee reliable results.
 
+The following example shows how the client should synchronize the state when the user has continuous input, assuming user input triggered `textDocument/completion`:
+
+| Document Version | User Input          | Client Behavior                                 | Request                   |
+| ---------------- | ------------------- | ----------------------------------------------- | ------------------------- |
+| 5                | document change one | sync document `v5` to the server                | `textDocument/didChange`  |
+| 5                | -                   | request from the server, based on document `v5` | `textDocument/completion` |
+| 6                | document change two | sync document `v6` to the server                | `textDocument/didChange`  |
+
 _Client Capability_:
 See general synchronization [client capabilities](#textDocument_synchronization_cc).
 

--- a/_specifications/lsp/3.18/textDocument/didChange.md
+++ b/_specifications/lsp/3.18/textDocument/didChange.md
@@ -2,6 +2,8 @@
 
 The document change notification is sent from the client to the server to signal changes to a text document. Before a client can change a text document it must claim ownership of its content using the `textDocument/didOpen` notification. In 2.0 the shape of the params has changed to include proper version numbers.
 
+Before requesting information from the server (e.g., `textDocument/completion` or `textDocument/signatureHelp`), the client must ensure that the document's state is synchronized with the server to guarantee reliable results.
+
 _Client Capability_:
 See general synchronization [client capabilities](#textDocument_synchronization_cc).
 


### PR DESCRIPTION
Copy this [discussion](https://github.com/microsoft/language-server-protocol/issues/2011#issuecomment-2343081904) to the document.

This content could help language server developers to safely handle signature help and completion requests after the compilation and I think the compilation is usually triggered by `didChange` event.