### PR TITLE
Add support for `completionList.applyKind` to determine how values from `completionList.itemDefaults` and `completion` are combined.

### DIFF
--- a/_specifications/lsp/3.18/language/completion.md
+++ b/_specifications/lsp/3.18/language/completion.md
@@ -166,6 +166,18 @@ export interface CompletionClientCapabilities {
 		 * @since 3.17.0
 		 */
 		itemDefaults?: string[];
+
+		/**
+		 * Specifies which fields of `CompletionList.applyKind` the client
+		 * supports. If omitted, no properties are supported and all fields
+		 * in a completion item will replace the defaults.
+		 * 
+		 * Clients may only specify fields that have merge rules defined in the
+		 * LSP spec.
+		 *
+		 * @since 3.18.0
+		 */
+		applyKinds?: string[];
 	}
 }
 ```
@@ -338,7 +350,8 @@ export interface CompletionList {
 	 * be used if a completion item itself doesn't specify the value.
 	 *
 	 * If a completion list specifies a default value and a completion item
-	 * also specifies a corresponding value, the one from the item is used.
+	 * also specifies a corresponding value, the rules for combining these are
+	 * defined by `applyKinds`, defaulting to "replace".
 	 *
 	 * Servers are only allowed to return default values if the client
 	 * signals support for this via the `completionList.itemDefaults`
@@ -384,6 +397,68 @@ export interface CompletionList {
 		 * @since 3.17.0
 		 */
 		data?: LSPAny;
+	}
+
+	/**
+	 * Specifies how fields from a completion item should be combined with those
+	 * from `completionList.itemDefaults`.
+	 * 
+	 * In unspecified, all fields will be treated as "replace".
+	 * 
+	 * If a field's value is "replace", the value from a completion item will
+	 * always be used instead of the value from `completionItem.itemDefaults`.
+	 * 
+	 * If a field's value is "merge", the values will be merged using the rules
+	 * defined against each field below.
+	 *
+	 * Servers are only allowed to return `applyKind` if the client
+	 * signals support for this via the `completionList.applyKinds`
+	 * capability.
+	 *
+	 * @since 3.18.0
+	 */
+	applyKind?: {
+		/**
+		 * Specifies whether commitCharacters on a completion will replace or be
+		 * merged with those in `completionList.itemDefaults.commitCharacters`.
+		 * 
+		 * If "replace", the commit characters from the completion item will
+		 * always be used unless not provided, in which case those from
+		 * `completionList.itemDefaults.commitCharacters` will be used. An empty
+		 * list can be used if a completion item does not have any commit
+		 * characters and also should not use those from
+		 * `completionList.itemDefaults.commitCharacters`.
+		 * 
+		 * If "merge" the commitCharacters for the completion will be the union
+		 * of all values in both `completionList.itemDefaults.commitCharacters`
+		 * and the completion's own `commitCharacters`.
+		 *
+		 * @since 3.18.0
+		 */
+		commitCharacters?: "replace" | "merge";
+
+		/**
+		 * Specifies whether data on a completion will replace or
+		 * be merged with data from `completionList.itemDefaults.data`.
+		 * 
+		 * If "replace", the data from the completion item will be used if
+		 * provided, otherwise  `completionList.itemDefaults.data` will be used.
+		 * An empty object can be used if a completion item does not have any
+		 * data but also should not use the value from
+		 * `completionList.itemDefaults.data`.
+		 * 
+		 * If "merge", a shallow merge will be performed between
+		 * `completionList.itemDefaults.data` and the completion's own data
+		 * using the following rules:
+		 * 
+		 * - If a field is specified in `completion.data` it will be used as-is.
+		 * - If a field is `null` in `completion.data`, it will remain `null`.
+		 * - If a field is unspecified in `completion.data`, the same field from
+		 *   `completionList.itemDefaults.data` will be used.
+		 *
+		 * @since 3.18.0
+		 */
+		data?: "replace" | "merge";
 	}
 
 	/**

--- a/_specifications/lsp/3.18/language/completion.md
+++ b/_specifications/lsp/3.18/language/completion.md
@@ -407,7 +407,7 @@ export interface CompletionList {
 	 * Specifies how fields from a completion item should be combined with those
 	 * from `completionList.itemDefaults`.
 	 * 
-	 * In unspecified, all fields will be treated as ApplyKind.Replace.
+	 * If unspecified, all fields will be treated as ApplyKind.Replace.
 	 * 
 	 * If a field's value is ApplyKind.Replace, the value from a completion item
 	 * (if provided and not `null`) will always be used instead of the value

--- a/_specifications/lsp/3.18/language/completion.md
+++ b/_specifications/lsp/3.18/language/completion.md
@@ -171,6 +171,12 @@ export interface CompletionClientCapabilities {
 		 * Specifies whether the client supports `CompletionList.applyKind` to
 		 * indicate how supported values from `completionList.itemDefaults`
 		 * and `completion` will be combined.
+		 * 
+		 * If a client supports `applyKind` it must support it for all fields
+		 * that it supports that are listed in `CompletionList.applyKind`. This
+		 * means when clients add support for new/future fields in completion
+		 * items the MUST also support merge for them if those fields are
+		 * defined in `CompletionList.applyKind`.
 		 *
 		 * @since 3.18.0
 		 */

--- a/_specifications/lsp/3.18/language/completion.md
+++ b/_specifications/lsp/3.18/language/completion.md
@@ -428,8 +428,8 @@ export interface CompletionList {
 		 * merged with those in `completionList.itemDefaults.commitCharacters`.
 		 * 
 		 * If "replace", the commit characters from the completion item will
-		 * always be used unless not provided (or `null`), in which case those
-		 * from `completionList.itemDefaults.commitCharacters` will be used. An
+		 * always be used unless not provided, in which case those from
+		 * `completionList.itemDefaults.commitCharacters` will be used. An
 		 * empty list can be used if a completion item does not have any commit
 		 * characters and also should not use those from
 		 * `completionList.itemDefaults.commitCharacters`.
@@ -620,7 +620,7 @@ export namespace ApplyKind {
 	 * The value from the individual item (if provided and not `null`) will be
 	 * used instead of the default.
 	 */
-	export const Replace: 'replace' = 'replace;
+	export const Replace: 'replace' = 'replace';
 
 	/**
 	 * The value from the item will be merged with the default.
@@ -631,7 +631,7 @@ export namespace ApplyKind {
 	export const Merge: 'merge' = 'merge';
 }
 
-export type ApplyKind = ApplyKind.Replace | ApplyKind.Merge;
+export type ApplyKind = 'replace' | 'merge';
 ```
 
 <div class="anchorHolder"><a href="#completionItem" name="completionItem" class="linkableAnchor"></a></div>

--- a/_specifications/lsp/3.18/language/completion.md
+++ b/_specifications/lsp/3.18/language/completion.md
@@ -405,8 +405,10 @@ export interface CompletionList {
 	 * 
 	 * In unspecified, all fields will be treated as "replace".
 	 * 
-	 * If a field's value is "replace", the value from a completion item will
-	 * always be used instead of the value from `completionItem.itemDefaults`.
+	 * If a field's value is "replace", the value from a completion item (if
+	 * provided) will always be used instead of the value from
+	 * `completionItem.itemDefaults`. `null` values are treated the same as a
+	 * value that was not provided.
 	 * 
 	 * If a field's value is "merge", the values will be merged using the rules
 	 * defined against each field below.
@@ -423,17 +425,15 @@ export interface CompletionList {
 		 * merged with those in `completionList.itemDefaults.commitCharacters`.
 		 * 
 		 * If "replace", the commit characters from the completion item will
-		 * always be used unless not provided, in which case those from
-		 * `completionList.itemDefaults.commitCharacters` will be used. An empty
-		 * list can be used if a completion item does not have any commit
+		 * always be used unless not provided (or `null`), in which case those
+		 * from `completionList.itemDefaults.commitCharacters` will be used. An
+		 * empty list can be used if a completion item does not have any commit
 		 * characters and also should not use those from
 		 * `completionList.itemDefaults.commitCharacters`.
 		 * 
 		 * If "merge" the commitCharacters for the completion will be the union
 		 * of all values in both `completionList.itemDefaults.commitCharacters`
-		 * and the completion's own `commitCharacters`. An empty list indicates
-		 * the completion adds no additional commit characters and a value of
-		 * `null` indicates the defaults should not be used.
+		 * and the completion's own `commitCharacters`.
 		 *
 		 * @since 3.18.0
 		 */
@@ -444,24 +444,20 @@ export interface CompletionList {
 		 * be merged with data from `completionList.itemDefaults.data`.
 		 * 
 		 * If "replace", the data from the completion item will be used if
-		 * provided, otherwise  `completionList.itemDefaults.data` will be used.
-		 * An empty object can be used if a completion item does not have any
-		 * data but also should not use the value from
-		 * `completionList.itemDefaults.data`.
+		 * provided (and not `null`), otherwise
+		 * `completionList.itemDefaults.data` will be used. An empty object can
+		 * be used if a completion item does not have any data but also should
+		 * not use the value from `completionList.itemDefaults.data`.
 		 * 
 		 * If "merge", a shallow merge will be performed between
 		 * `completionList.itemDefaults.data` and the completion's own data
 		 * using the following rules:
 		 * 
-		 * - If a completion's data is not specified, the data from
-		 *   `completionList.itemDefaults.data` will be used.
-		 * - If a completion's data is null, the resulting data field will be
-		 *   null (defaults are not used).
-		 * - If a field is specified in `completion.data` it will be used as-is.
-		 * - If a field is `null` in `completion.data`, it will remain `null`
-		 *   (default is not used).
-		 * - If a field is unspecified in `completion.data`, the same field from
-		 *   `completionList.itemDefaults.data` will be used.
+		 * - If a completion's `data` field is not provided (or `null`), the
+		 *   data from `completionList.itemDefaults.data` will be used as-is.
+		 * - If a completion's `data` is provided, each field will overwrite the
+		 *   field of the same name in `completionList.itemDefaults.data` but
+		 *   no merging of fields within that value will occur.
 		 *
 		 * @since 3.18.0
 		 */

--- a/_specifications/lsp/3.18/language/completion.md
+++ b/_specifications/lsp/3.18/language/completion.md
@@ -355,7 +355,7 @@ export interface CompletionList {
 	 * If a completion list specifies a default value and a completion item
 	 * also specifies a corresponding value, the rules for combining these are
 	 * defined by `applyKinds` (if the client supports it), defaulting to
-	 * "replace".
+	 * ApplyKind.Replace.
 	 *
 	 * Servers are only allowed to return default values if the client
 	 * signals support for this via the `completionList.itemDefaults`
@@ -407,14 +407,14 @@ export interface CompletionList {
 	 * Specifies how fields from a completion item should be combined with those
 	 * from `completionList.itemDefaults`.
 	 * 
-	 * In unspecified, all fields will be treated as "replace".
+	 * In unspecified, all fields will be treated as ApplyKind.Replace.
 	 * 
-	 * If a field's value is "replace", the value from a completion item (if
-	 * provided and not `null`) will always be used instead of the value from
-	 * `completionItem.itemDefaults`.
+	 * If a field's value is ApplyKind.Replace, the value from a completion item
+	 * (if provided and not `null`) will always be used instead of the value
+	 * from `completionItem.itemDefaults`.
 	 * 
-	 * If a field's value is "merge", the values will be merged using the rules
-	 * defined against each field below.
+	 * If a field's value is ApplyKind.Merge, the values will be merged using
+	 * the rules defined against each field below.
 	 *
 	 * Servers are only allowed to return `applyKind` if the client
 	 * signals support for this via the `completionList.applyKindSupport`
@@ -427,16 +427,17 @@ export interface CompletionList {
 		 * Specifies whether commitCharacters on a completion will replace or be
 		 * merged with those in `completionList.itemDefaults.commitCharacters`.
 		 * 
-		 * If "replace", the commit characters from the completion item will
-		 * always be used unless not provided, in which case those from
+		 * If ApplyKind.Replace, the commit characters from the completion item
+		 * will always be used unless not provided, in which case those from
 		 * `completionList.itemDefaults.commitCharacters` will be used. An
 		 * empty list can be used if a completion item does not have any commit
 		 * characters and also should not use those from
 		 * `completionList.itemDefaults.commitCharacters`.
 		 * 
-		 * If "merge" the commitCharacters for the completion will be the union
-		 * of all values in both `completionList.itemDefaults.commitCharacters`
-		 * and the completion's own `commitCharacters`.
+		 * If ApplyKind.Merge the commitCharacters for the completion will be
+		 * the union of all values in both
+		 * `completionList.itemDefaults.commitCharacters` and the completion's
+		 * own `commitCharacters`.
 		 *
 		 * @since 3.18.0
 		 */
@@ -446,13 +447,13 @@ export interface CompletionList {
 		 * Specifies whether the `data` field on a completion will replace or
 		 * be merged with data from `completionList.itemDefaults.data`.
 		 * 
-		 * If "replace", the data from the completion item will be used if
-		 * provided (and not `null`), otherwise
+		 * If ApplyKind.Replace, the data from the completion item will be used
+		 * if provided (and not `null`), otherwise
 		 * `completionList.itemDefaults.data` will be used. An empty object can
 		 * be used if a completion item does not have any data but also should
 		 * not use the value from `completionList.itemDefaults.data`.
 		 * 
-		 * If "merge", a shallow merge will be performed between
+		 * If ApplyKind.Merge, a shallow merge will be performed between
 		 * `completionList.itemDefaults.data` and the completion's own data
 		 * using the following rules:
 		 * 
@@ -614,24 +615,32 @@ export interface CompletionItemLabelDetails {
 /**
  * Defines how values from a set of defaults and an individual item will be
  * merged.
+ *
+ * @since 3.18.0
  */
 export namespace ApplyKind {
 	/**
 	 * The value from the individual item (if provided and not `null`) will be
 	 * used instead of the default.
 	 */
-	export const Replace: 'replace' = 'replace';
+	export const Replace: 1 = 1;
 
 	/**
 	 * The value from the item will be merged with the default.
-	 * 
+	 *
 	 * The specific rules for mergeing values are defined against each field
 	 * that supports merging.
 	 */
-	export const Merge: 'merge' = 'merge';
+	export const Merge: 2 = 2;
 }
 
-export type ApplyKind = 'replace' | 'merge';
+/**
+ * Defines how values from a set of defaults and an individual item will be
+ * merged.
+ *
+ * @since 3.18.0
+ */
+export type ApplyKind = 1 | 2;
 ```
 
 <div class="anchorHolder"><a href="#completionItem" name="completionItem" class="linkableAnchor"></a></div>

--- a/_specifications/lsp/3.18/language/completion.md
+++ b/_specifications/lsp/3.18/language/completion.md
@@ -431,7 +431,9 @@ export interface CompletionList {
 		 * 
 		 * If "merge" the commitCharacters for the completion will be the union
 		 * of all values in both `completionList.itemDefaults.commitCharacters`
-		 * and the completion's own `commitCharacters`.
+		 * and the completion's own `commitCharacters`. An empty list indicates
+		 * the completion adds no additional commit characters and a value of
+		 * `null` indicates the defaults should not be used.
 		 *
 		 * @since 3.18.0
 		 */
@@ -451,8 +453,13 @@ export interface CompletionList {
 		 * `completionList.itemDefaults.data` and the completion's own data
 		 * using the following rules:
 		 * 
+		 * - If a completion's data is not specified, the data from
+		 *   `completionList.itemDefaults.data` will be used.
+		 * - If a completion's data is null, the resulting data field will be
+		 *   null (defaults are not used).
 		 * - If a field is specified in `completion.data` it will be used as-is.
-		 * - If a field is `null` in `completion.data`, it will remain `null`.
+		 * - If a field is `null` in `completion.data`, it will remain `null`
+		 *   (default is not used).
 		 * - If a field is unspecified in `completion.data`, the same field from
 		 *   `completionList.itemDefaults.data` will be used.
 		 *

--- a/_specifications/lsp/3.18/specification.md
+++ b/_specifications/lsp/3.18/specification.md
@@ -737,6 +737,7 @@ Since 3.17 there is a meta model describing the LSP protocol:
 * Support for snippets in text document edits.
 * Support for debug message kind.
 * Client capability to enumerate properties that can be resolved for code lenses.
+* Added support for `completionList.applyKind` to determine how values from `completionList.itemDefaults` and `completion` are combined.
 
 
 #### <a href="#version_3_17_0" name="version_3_17_0" class="anchor">3.17.0 (05/10/2022)</a>


### PR DESCRIPTION
The goal here is to significantly reduce payload sizes by allowing the server to avoid duplicating values across all `completion.commitCharacters` and `completion.data` that are the same for all (or most) items.

Only the fields specified in the spec support `merge` because the exact merge semantics must be specified. A client capability indicates which fields a given client supports merging.

@dbaeumer I implemented it this way because I worry that a single boolean may cause issues in future if new fields are added that we might want to support merge for, but I am happy to change if you don't like this.

Fixes https://github.com/microsoft/language-server-protocol/issues/1802