### PR TITLE
Added Rascal to relevant LSP implementor sections

### DIFF
--- a/_implementors/sdks.md
+++ b/_implementors/sdks.md
@@ -28,6 +28,7 @@ index: 3
 | Python | [Open Law Library](http://www.openlawlib.org/) | [pygls](https://github.com/openlawlibrary/pygls)|
 | Python | [Yeger](https://github.com/yeger00) | [pylspclient](https://github.com/yeger00/pylspclient)|
 | Python | [Microsoft](https://github.com/microsoft) | [multilspy](https://github.com/microsoft/monitors4codegen#4-multilspy)|
+| Rascal | [UseTheSource](https://github.com/UseTheSource) | [rascal-language-servers](https://github.com/usethesource/rascal-language-servers) |
 | Ruby | [Fumiaki MATSUSHIMA](https://github.com/mtsmfm) | [LanguageServer::Protocol](https://github.com/mtsmfm/language_server-protocol-ruby) |
 | Rust | [Bruno Medeiros](https://github.com/bruno-medeiros) | [RustLSP](https://github.com/RustDT/RustLSP)|
 | Rust | Bruno Medeiros and Markus Westerlind | [lsp-types](https://github.com/gluon-lang/lsp-types)

--- a/_implementors/servers.md
+++ b/_implementors/servers.md
@@ -191,6 +191,7 @@ index: 1
 | Racket | [Jay McCarthy](https://github.com/jeapostrophe) | [racket-langserver](https://github.com/jeapostrophe/racket-langserver) | Racket |
 | Raku | [Brian Scannell](https://github.com/bscan) | [Raku Navigator](https://github.com/bscan/RakuNavigator) | TypeScript |
 | RAML | [RAML Workgroup](http://raml.org/about/workgroup) | [raml-language-server](https://github.com/raml-org/raml-language-server) Work in Progress | |
+| [Rascal](https://www.rascal-mpl.org/) | [UseTheSource](https://github.com/UseTheSource) | [util::LanguageServer](https://github.com/usethesource/rascal-language-servers) | Java & Rascal & Typescript |
 | [RAML](https://raml.org/) | [AML](https://a.ml/) | [AML Language Server](https://github.com/aml-org/als) | ScalaJS |
 | ReasonML| [Jared Forsyth](https://github.com/jaredly) | [reason-language-server](https://github.com/jaredly/reason-language-server) | OCaml |
 | Red | [bitbegin](https://github.com/bitbegin) | [redlangserver](https://github.com/bitbegin/redlangserver) | Red |


### PR DESCRIPTION
The same server is used for the Rascal meta-programming language itself and as a LSP server generator for any DSL/GPL defined in Rascal. 

- [VS Code extension](https://marketplace.visualstudio.com/items?itemName=UseTheSource.rascalmpl)
- [npm companion module](https://www.npmjs.com/package/@usethesource/rascal-vscode-dsl-lsp-server) (used to build VS Code extensions that are deployable)