### PR TITLE
Clarify snippet placeholder structure

### DIFF
--- a/_specifications/lsp/3.18/language/completion.md
+++ b/_specifications/lsp/3.18/language/completion.md
@@ -934,7 +934,7 @@ ${TM_FILENAME/(.*)\..+$/$1/}
 Below is the grammar for snippets in EBNF ([extended Backus-Naur form, XML variant](https://www.w3.org/TR/xml/#sec-notation)). With `\` (backslash), you can escape `$`, `}` and `\`. Within choice elements, the backslash also escapes comma and pipe characters. Only the characters required to be escaped can be escaped, so `$` should not be escaped within these constructs and neither `$` nor `}` should be escaped inside choice constructs.
 
 ```
-any         ::= tabstop | placeholder | choice | variable | text
+any         ::= (tabstop | placeholder | choice | variable | text)+
 tabstop     ::= '$' int | '${' int '}'
 placeholder ::= '${' int ':' any '}'
 choice      ::= '${' int '|' choicetext (',' choicetext)* '|}'


### PR DESCRIPTION
Now grammar implies that placeholder value should be a single `any` node, while in most applications it can be any number of consecutive `any` nodes. For example, as described in earlier "Placeholders" section: `${1:another ${2:placeholder}}`.

Using `any+` instead of `any` seems to be more precise.