### PR TITLE
cython-lsp

### DIFF
--- a/_implementors/servers.md
+++ b/_implementors/servers.md
@@ -66,6 +66,7 @@ index: 1
 | [Crystal](https://crystal-lang.org/)| [Elbaz Julien](https://github.com/elbywan) | [Crystalline](https://github.com/elbywan/crystalline) | Crystal |
 | [Crystal](https://crystal-lang.org/)| [Ryan L. Bell](https://github.com/kofno) | [Scry](https://github.com/crystal-lang-tools/scry) | Crystal |
 | [Cucumber/Gherkin](https://cucumber.io/)| [Cucumber core team](https://github.com/cucumber) | [Cucumber Language Server](https://github.com/cucumber/language-server) | TypeScript |
+| [Cython](https://cython.org/) | [ktnrg45](https://github.com/ktnrg45) | [cyright](https://github.com/ktnrg45/cyright) | TypeScript |
 | [D](https://dlang.org) | [Jan Jurzitza](https://github.com/WebFreak001) | [serve-d](https://github.com/Pure-D/serve-d) | D |
 | [D](https://dlang.org) | [Laurent Tréguier](https://github.com/LaurentTreguier) | [D Language Server](https://github.com/d-language-server/dls) | D |
 | [Dart](https://dart.dev/) | [Dart Team](https://dart.dev/) | [Dart SDK](https://github.com/dart-lang/sdk/blob/master/pkg/analysis_server/tool/lsp_spec/README.md) | Dart |


### PR DESCRIPTION
all the "python" code in the repo is pyi file <https://github.com/search?q=repo%3Aktnrg45%2Fcyright++language%3APython&type=code>, so it's written in typescript.
