### PR TITLE
Snippet support for tabstop, camel/pascal case transforms

### DIFF
--- a/_specifications/lsp/3.18/language/completion.md
+++ b/_specifications/lsp/3.18/language/completion.md
@@ -935,15 +935,18 @@ Below is the grammar for snippets in EBNF ([extended Backus-Naur form, XML varia
 
 ```
 any         ::= tabstop | placeholder | choice | variable | text
-tabstop     ::= '$' int | '${' int '}'
+tabstop     ::= '$' int
+                | '${' int '}'
+                | '${' int  transform '}'
 placeholder ::= '${' int ':' any '}'
 choice      ::= '${' int '|' choicetext (',' choicetext)* '|}'
 variable    ::= '$' var | '${' var }'
                 | '${' var ':' any '}'
-                | '${' var '/' regex '/' (format | formattext)* '/' options '}'
+                | '${' var transform '}'
+transform   ::= '/' regex '/' (format | formattext)* '/' options
 format      ::= '$' int | '${' int '}'
-                /* Transforms the text to be uppercase, lowercase, or capitalized, respectively. */
-                | '${' int ':' ('/upcase' | '/downcase' | '/capitalize') '}'
+                /* Transforms the text to be uppercase, lowercase, capitalized, camelcase, or pascalcase, respectively. */
+                | '${' int ':' ('/upcase' | '/downcase' | '/capitalize' | '/camelcase' | '/pascalcase') '}'
                 /* Inserts the 'ifOnly' text if the match is non-empty. */
                 | '${' int ':+' ifOnly '}'
                 /* Inserts the 'if' text if the match is non-empty,
@@ -951,8 +954,8 @@ format      ::= '$' int | '${' int '}'
                 | '${' int ':?' if ':' else '}'
                 /* Inserts the 'else' text if the match is empty. */
                 | '${' int ':-' else '}' | '${' int ':' else '}'
-regex       ::= Regular Expression value (ctor-string)
-options     ::= Regular Expression option (ctor-options)
+regex       ::= JavaScript Regular Expression value (ctor-string)
+options     ::= JavaScript Regular Expression option (ctor-options)
 var         ::= [_a-zA-Z] [_a-zA-Z0-9]*
 int         ::= [0-9]+
 text        ::= ([^$}\] | '\$' | '\}' | '\\')*


### PR DESCRIPTION
Allows tabstops to take regex transformations, and also allows for the use of `camelcase` and `pascalcase` directives.

Based on the documentation found in VSCode:

https://github.com/microsoft/vscode/blob/7ec55aa30e27ce6eca38156f1302ff4cc0db0dbe/src/vs/editor/contrib/snippet/browser/snippet.md?plain=1#L118