### PR TITLE
Clarify that `$0` should not use any other snippet syntax

### DIFF
--- a/_specifications/lsp/3.18/language/completion.md
+++ b/_specifications/lsp/3.18/language/completion.md
@@ -879,7 +879,9 @@ The `body` of a snippet can use special constructs to control cursors and the te
 
 ##### Tab stops
 
-With tab stops, you can make the editor cursor move inside a snippet. Use `$1`, `$2`, and so on to specify cursor locations. The number is the order in which tab stops will be visited, whereas `$0` denotes the final cursor position. Multiple tab stops are linked and updated in sync.
+With tab stops, you can make the editor cursor move inside a snippet. Use `$1`, `$2`, and so on to specify cursor locations. The number is the order in which tab stops will be visited. Multiple tab stops are linked and updated in sync.
+
+The `$0` tab stop denotes the final cursor position. This tab stop should not be combined with other snippet syntax - placeholders, choices, variables or transforms - it should only take the form `$0`.
 
 ##### Placeholders
 


### PR DESCRIPTION
This change clarifies that the zero tab stop (`$0`) should not be combined with other snippet syntax like placeholders, for example `sizeof(${0:expression-or-type})` from an older version of `clangd`. (That example should be `sizeof($0)` or `sizeof(${1:expression-or-type})$0` instead.) I believe this aligns with how VSCode treats `$0` (https://github.com/microsoft/vscode/issues/152837) as well as Neovim, and it's how we treat `$0` now in Helix (https://github.com/helix-editor/helix/pull/12647), at least for placeholders so far.

Fixes #1946