### PR TITLE
add Wikitext LSP to the list

### DIFF
--- a/_implementors/servers.md
+++ b/_implementors/servers.md
@@ -280,6 +280,7 @@ index: 1
 | [WebAssembly](https://webassembly.org/) | [Pig Fang](https://github.com/g-plane) | [wasm-language-tools](https://github.com/g-plane/wasm-language-tools) | Rust |
 | [WebAssembly](https://webassembly.org/) | [Darin Morrison](https://github.com/darinmorrison) | [wasm-language-server](https://github.com/wasm-lsp/wasm-language-server) | Rust |
 | [WebGPU Shading Language](https://gpuweb.github.io/gpuweb/wgsl/) | [WGSL-Analyzer Team](https://github.com/wgsl-analyzer) | [wgsl-analyzer](https://github.com/wgsl-analyzer/wgsl-analyzer) | Rust |
+| [Wikitext](https://mediawiki.org/wiki/Wikitext) | [Bhsd](https://github.com/bhsd-harry) | [VSCode-WikiParser](https://github.com/bhsd-harry/vscode-extension-wikiparser) | TypeScript
 | [Wing](https://www.winglang.io/) | [Contributors](https://github.com/winglang/wing/graphs/contributors) | [Wing](https://github.com/winglang/wing) | Typescript |
 | [Wolfram Language](https://www.wolfram.com/language/) ([Mathematica](https://www.wolfram.com/mathematica)) | [kenkangxgwe](https://github.com/kenkangxgwe) | [lsp-wl](https://github.com/kenkangxgwe/lsp-wl) | Wolfram Language |
 | [Wolfram Language](https://www.wolfram.com) | [Wolfram Research](https://github.com/WolframResearch) | [LSPServer](https://github.com/WolframResearch/lspserver) | Wolfram Language |


### PR DESCRIPTION
VSCode-Wikiparser is a language server for MediaWiki Wikitext written with vscode-languageserver/node.