### PR TITLE
Specify that an editor should fallback to unresolved code action if resolve request fails

### DIFF
--- a/_specifications/lsp/3.18/language/codeAction.md
+++ b/_specifications/lsp/3.18/language/codeAction.md
@@ -570,6 +570,8 @@ then a code action
 
 needs to be resolved using the `codeAction/resolve` request before it can be applied.
 
+If the resolve request fails, the editor should try to apply the edit or command from the unresolved code action.
+
 _Client Capability_:
 * property name (optional): `textDocument.codeAction.resolveSupport`
 * property type: `{ properties: string[]; }`


### PR DESCRIPTION
[VS Code](https://github.com/microsoft/vscode/blob/2b3cb533550639a43a144968b07576998a880718/src/vs/workbench/api/common/extHostLanguageFeatures.ts#L559), [Helix](https://github.com/helix-editor/helix/blob/19558839b72717a5fc1d1620f73e7a9dfc5dfd6a/helix-term/src/commands/lsp.rs#L794-L795) and (soon) [Neovim](https://github.com/neovim/neovim/pull/32764) all fallback to the original code action when resolve fails.

To avoid issues like https://github.com/neovim/neovim/issues/32757 where it's unclear what an editor should do in the scenario where the language server errors when resolving the code action, let's specify what the standard behavior should be.