### PR TITLE
Add `WorkspaceFoldersClientCapabilities`

### DIFF
--- a/_specifications/lsp/3.18/metaModel/metaModel.json
+++ b/_specifications/lsp/3.18/metaModel/metaModel.json
@@ -2081,6 +2081,7 @@
 			"method": "workspace/didChangeWorkspaceFolders",
 			"typeName": "DidChangeWorkspaceFoldersNotification",
 			"messageDirection": "clientToServer",
+			"clientCapability": "workspace.workspaceFolders.changeNotifications",
 			"serverCapability": "workspace.workspaceFolders.changeNotifications",
 			"params": {
 				"kind": "reference",
@@ -11206,8 +11207,17 @@
 				{
 					"name": "workspaceFolders",
 					"type": {
-						"kind": "base",
-						"name": "boolean"
+						"kind": "or",
+						"items": [
+							{
+								"kind": "base",
+								"name": "boolean"
+							},
+							{
+								"kind": "reference",
+								"name": "WorkspaceFoldersClientCapabilities"
+							}
+						]
 					},
 					"optional": true,
 					"documentation": "The client has support for workspace folders.\n\n@since 3.6.0",
@@ -12255,6 +12265,33 @@
 				}
 			],
 			"documentation": "The client capabilities of a {@link ExecuteCommandRequest}."
+		},
+		{
+			"name": "WorkspaceFoldersClientCapabilities",
+			"properties": [
+				{
+					"name": "changeNotifications",
+					"type": {
+						"kind": "literal",
+						"value": {
+							"properties": [
+								{
+									"name": "dynamicRegistration",
+									"type": {
+										"kind": "base",
+										"name": "boolean"
+									},
+									"optional": true,
+									"documentation": "Whether the client supports dynamic registration for the\n`workspace/didChangeWorkspaceFolders` notification."
+								}
+							]
+						}
+					},
+					"optional": true,
+					"documentation": "The client has support for workspace folder change notifications.\n\n@since 3.18.0",
+					"since": "3.18.0"
+				}
+			]
 		},
 		{
 			"name": "SemanticTokensWorkspaceClientCapabilities",

--- a/_specifications/lsp/3.18/workspace/workspaceFolders.md
+++ b/_specifications/lsp/3.18/workspace/workspaceFolders.md
@@ -8,7 +8,24 @@ The `workspace/workspaceFolders` request is sent from the server to the client t
 
 _Client Capability_:
 * property path (optional): `workspace.workspaceFolders`
-* property type: `boolean`
+* property type: `boolean | WorkspaceFoldersClientCapabilities` where `WorkspaceFoldersClientCapabilities` is defined as follows:
+
+```typescript
+export interface WorkspaceFoldersClientCapabilities {
+	/**
+	* The client has support for workspace folder change notifications.
+	*
+	* @since 3.18.0
+	*/
+	changeNotifications?: {
+		/**
+		 * Whether the client supports dynamic registration for the
+		 * `workspace/didChangeWorkspaceFolders` notification.
+		 */
+		dynamicRegistration?: boolean;
+	};
+}
+```
 
 _Server Capability_:
 * property path (optional): `workspace.workspaceFolders`


### PR DESCRIPTION
Closes https://github.com/microsoft/language-server-protocol/issues/2133

Complements https://github.com/microsoft/vscode-languageserver-node/pull/1627 which contains the respective updates to the VS Code LSP implementation.