### PR TITLE
chore: Add Nobl9 VSCode extension to servers.md

### DIFF
--- a/_implementors/servers.md
+++ b/_implementors/servers.md
@@ -160,7 +160,7 @@ index: 1
 | [NASM/GO/GAS Assembly](https://en.wikipedia.org/wiki/Assembly_language) | [Contributors](https://github.com/bergercookie/asm-lsp/graphs/contributors) | [asm-lsp](https://github.com/bergercookie/asm-lsp) | Rust |
 | Nginx | [pappasam](https://github.com/pappasam) | [nginx-language-server](https://github.com/pappasam/nginx-language-server) | Python |
 | [Nim](https://nim-lang.org/) | [Peter Munch-Ellingsen](https://github.com/PMunch) | [nimlsp](https://github.com/PMunch/nimlsp) | Nim |
-| [Nobl9 YAML](https://docs.nobl9.com/yaml-guide) | Nobl9 | [nobl9-vscode](https://github.com/nobl9/nobl9-vscode/) | Go |
+| [Nobl9 YAML](https://docs.nobl9.com/yaml-guide) | [Nobl9](https://www.nobl9.com/) | [nobl9-vscode](https://github.com/nobl9/nobl9-vscode/) | Go |
 | OCaml/Reason | [freebroccolo](https://github.com/freebroccolo) | [ocaml-language-server](https://github.com/freebroccolo/ocaml-language-server) | TypeScript |
 | OCaml/Reason | [OCaml Labs](http://ocamllabs.io) | [ocamllsp](https://github.com/ocaml/ocaml-lsp) | OCaml |
 | [Odin](https://odin-lang.org) | [Daniel Gavin](https://github.com/DanielGavin/) | [ols](https://github.com/DanielGavin/ols) | Odin | 

--- a/_implementors/servers.md
+++ b/_implementors/servers.md
@@ -160,6 +160,7 @@ index: 1
 | [NASM/GO/GAS Assembly](https://en.wikipedia.org/wiki/Assembly_language) | [Contributors](https://github.com/bergercookie/asm-lsp/graphs/contributors) | [asm-lsp](https://github.com/bergercookie/asm-lsp) | Rust |
 | Nginx | [pappasam](https://github.com/pappasam) | [nginx-language-server](https://github.com/pappasam/nginx-language-server) | Python |
 | [Nim](https://nim-lang.org/) | [Peter Munch-Ellingsen](https://github.com/PMunch) | [nimlsp](https://github.com/PMunch/nimlsp) | Nim |
+| [Nobl9 YAML](https://docs.nobl9.com/yaml-guide) | Nobl9 | [nobl9-vscode](https://github.com/nobl9/nobl9-vscode/) | Go |
 | OCaml/Reason | [freebroccolo](https://github.com/freebroccolo) | [ocaml-language-server](https://github.com/freebroccolo/ocaml-language-server) | TypeScript |
 | OCaml/Reason | [OCaml Labs](http://ocamllabs.io) | [ocamllsp](https://github.com/ocaml/ocaml-lsp) | OCaml |
 | [Odin](https://odin-lang.org) | [Daniel Gavin](https://github.com/DanielGavin/) | [ols](https://github.com/DanielGavin/ols) | Odin | 


### PR DESCRIPTION
Adds [nobl9-vscode](https://github.com/nobl9/nobl9-vscode/) to the list of supported LSP implementations.
It is an extension integrating [Nobl9 Language Server](https://github.com/nobl9/nobl9-language-server) for [Nobl9 YAML configuration files ](https://docs.nobl9.com/yaml-guide).