### PR TITLE
fix: improve readability of comment,

### DIFF
--- a/_specifications/lsp/3.17/language/documentSymbol.md
+++ b/_specifications/lsp/3.17/language/documentSymbol.md
@@ -216,8 +216,8 @@ export interface DocumentSymbol {
 	/**
 	 * The range enclosing this symbol not including leading/trailing whitespace
 	 * but everything else like comments. This information is typically used to
-	 * determine if the clients cursor is inside the symbol to reveal in the
-	 * symbol in the UI.
+	 * determine if the clients cursor is inside the symbol to reveal it  in the
+	 * UI.
 	 */
 	range: Range;
 

--- a/_specifications/specification-3-15.md
+++ b/_specifications/specification-3-15.md
@@ -4552,7 +4552,7 @@ export interface DocumentSymbol {
 	 * The range enclosing this symbol not including leading/trailing
 	 * whitespace but everything else like comments.
 	 * This information is typically used to determine if the client's cursor
-	 * is inside the symbol to reveal in the symbol in the UI.
+	 * is inside the symbol to reveal it in the UI.
 	 */
 	range: Range;
 

--- a/_specifications/specification-3-16.md
+++ b/_specifications/specification-3-16.md
@@ -5832,8 +5832,8 @@ export interface DocumentSymbol {
 	/**
 	 * The range enclosing this symbol not including leading/trailing whitespace
 	 * but everything else like comments. This information is typically used to
-	 * determine if the clients cursor is inside the symbol to reveal in the
-	 * symbol in the UI.
+	 * determine if the clients cursor is inside the symbol to reveal it in the
+	 * UI.
 	 */
 	range: Range;
 


### PR DESCRIPTION
I was reading through the spec and this sentence seemed a bit off due to the `in` and `symbol` alliteration.

I didn't find any contribution guides so not sure:
1. if my commit is formatted properly
2. if i should have changed the historical specs

Thanks in advance

