### PR TITLE
fix: `ServerCapability.referencesProvider` accepts `ReferenceRegistrationOptions` too

### DIFF
--- a/_specifications/lsp/3.17/general/initialize.md
+++ b/_specifications/lsp/3.17/general/initialize.md
@@ -723,7 +723,8 @@ interface ServerCapabilities {
 	/**
 	 * The server provides find references support.
 	 */
-	referencesProvider?: boolean | ReferenceOptions;
+	referencesProvider?: boolean | ReferenceOptions
+		| ReferenceRegistrationOptions;
 
 	/**
 	 * The server provides document highlight support.

--- a/_specifications/lsp/3.17/language/references.md
+++ b/_specifications/lsp/3.17/language/references.md
@@ -19,7 +19,7 @@ export interface ReferenceClientCapabilities {
 
 _Server Capability_:
 * property name (optional): `referencesProvider`
-* property type: `boolean | ReferenceOptions` where `ReferenceOptions` is defined as follows:
+* property type: `boolean | ReferenceOptions | ReferenceRegistrationOptions` where `ReferenceOptions` is defined as follows:
 
 <div class="anchorHolder"><a href="#referenceOptions" name="referenceOptions" class="linkableAnchor"></a></div>
 

--- a/_specifications/lsp/3.17/metaModel/metaModel.json
+++ b/_specifications/lsp/3.17/metaModel/metaModel.json
@@ -8297,6 +8297,10 @@
 							{
 								"kind": "reference",
 								"name": "ReferenceOptions"
+							},
+							{
+								"kind": "reference",
+								"name": "ReferenceRegistrationOptions"
 							}
 						]
 					},

--- a/_specifications/lsp/3.18/general/initialize.md
+++ b/_specifications/lsp/3.18/general/initialize.md
@@ -751,7 +751,8 @@ interface ServerCapabilities {
 	/**
 	 * The server provides find references support.
 	 */
-	referencesProvider?: boolean | ReferenceOptions;
+	referencesProvider?: boolean | ReferenceOptions
+		| ReferenceRegistrationOptions;
 
 	/**
 	 * The server provides document highlight support.

--- a/_specifications/lsp/3.18/language/references.md
+++ b/_specifications/lsp/3.18/language/references.md
@@ -19,7 +19,7 @@ export interface ReferenceClientCapabilities {
 
 _Server Capability_:
 * property name (optional): `referencesProvider`
-* property type: `boolean | ReferenceOptions` where `ReferenceOptions` is defined as follows:
+* property type: `boolean | ReferenceOptions | ReferenceRegistrationOptions` where `ReferenceOptions` is defined as follows:
 
 <div class="anchorHolder"><a href="#referenceOptions" name="referenceOptions" class="linkableAnchor"></a></div>
 

--- a/_specifications/lsp/3.18/metaModel/metaModel.json
+++ b/_specifications/lsp/3.18/metaModel/metaModel.json
@@ -8526,6 +8526,10 @@
 							{
 								"kind": "reference",
 								"name": "ReferenceOptions"
+							},
+							{
+								"kind": "reference",
+								"name": "ReferenceRegistrationOptions"
 							}
 						]
 					},

--- a/_specifications/specification-3-15.md
+++ b/_specifications/specification-3-15.md
@@ -4281,7 +4281,7 @@ export interface ReferenceClientCapabilities {
 
 _Server Capability_:
 * property name (optional): `referencesProvider`
-* property type: `boolean | ReferenceOptions` where `ReferenceOptions` is defined as follows:
+* property type: `boolean | ReferenceOptions | ReferenceRegistrationOptions` where `ReferenceOptions` is defined as follows:
 
 ```typescript
 export interface ReferenceOptions extends WorkDoneProgressOptions {

--- a/_specifications/specification-3-15.md
+++ b/_specifications/specification-3-15.md
@@ -1753,7 +1753,8 @@ interface ServerCapabilities {
 	/**
 	 * The server provides find references support.
 	 */
-	referencesProvider?: boolean | ReferenceOptions;
+	referencesProvider?: boolean | ReferenceOptions
+		| ReferenceRegistrationOptions;
 
 	/**
 	 * The server provides document highlight support.

--- a/_specifications/specification-3-16.md
+++ b/_specifications/specification-3-16.md
@@ -5504,7 +5504,7 @@ export interface ReferenceClientCapabilities {
 
 _Server Capability_:
 * property name (optional): `referencesProvider`
-* property type: `boolean | ReferenceOptions` where `ReferenceOptions` is defined as follows:
+* property type: `boolean | ReferenceOptions | ReferenceRegistrationOptions` where `ReferenceOptions` is defined as follows:
 
 ```typescript
 export interface ReferenceOptions extends WorkDoneProgressOptions {

--- a/_specifications/specification-3-16.md
+++ b/_specifications/specification-3-16.md
@@ -2246,7 +2246,8 @@ interface ServerCapabilities {
 	/**
 	 * The server provides find references support.
 	 */
-	referencesProvider?: boolean | ReferenceOptions;
+	referencesProvider?: boolean | ReferenceOptions
+		| ReferenceRegistrationOptions;
 
 	/**
 	 * The server provides document highlight support.


### PR DESCRIPTION
`ReferenceRegistrationOptions` is never been referenced in the specs