### PR TITLE
fix: `ServerCapability.documentHighlightProvider` accepts `DocumentHighlightRegistrationOptions` too

### DIFF
--- a/_specifications/lsp/3.17/general/initialize.md
+++ b/_specifications/lsp/3.17/general/initialize.md
@@ -728,7 +728,8 @@ interface ServerCapabilities {
 	/**
 	 * The server provides document highlight support.
 	 */
-	documentHighlightProvider?: boolean | DocumentHighlightOptions;
+	documentHighlightProvider?: boolean | DocumentHighlightOptions
+		| DocumentHighlightRegistrationOptions;
 
 	/**
 	 * The server provides document symbol support.

--- a/_specifications/lsp/3.17/language/documentHighlight.md
+++ b/_specifications/lsp/3.17/language/documentHighlight.md
@@ -22,7 +22,7 @@ export interface DocumentHighlightClientCapabilities {
 
 _Server Capability_:
 * property name (optional): `documentHighlightProvider`
-* property type: `boolean | DocumentHighlightOptions` where `DocumentHighlightOptions` is defined as follows:
+* property type: `boolean | DocumentHighlightOptions | DocumentHighlightRegistrationOptions` where `DocumentHighlightOptions` is defined as follows:
 
 <div class="anchorHolder"><a href="#documentHighlightOptions" name="documentHighlightOptions" class="linkableAnchor"></a></div>
 

--- a/_specifications/lsp/3.17/metaModel/metaModel.json
+++ b/_specifications/lsp/3.17/metaModel/metaModel.json
@@ -8315,6 +8315,10 @@
 							{
 								"kind": "reference",
 								"name": "DocumentHighlightOptions"
+							},
+							{
+								"kind": "reference",
+								"name": "DocumentHighlightRegistrationOptions"
 							}
 						]
 					},

--- a/_specifications/lsp/3.18/general/initialize.md
+++ b/_specifications/lsp/3.18/general/initialize.md
@@ -756,7 +756,8 @@ interface ServerCapabilities {
 	/**
 	 * The server provides document highlight support.
 	 */
-	documentHighlightProvider?: boolean | DocumentHighlightOptions;
+	documentHighlightProvider?: boolean | DocumentHighlightOptions
+		| DocumentHighlightRegistrationOptions;
 
 	/**
 	 * The server provides document symbol support.

--- a/_specifications/lsp/3.18/language/documentHighlight.md
+++ b/_specifications/lsp/3.18/language/documentHighlight.md
@@ -22,7 +22,7 @@ export interface DocumentHighlightClientCapabilities {
 
 _Server Capability_:
 * property name (optional): `documentHighlightProvider`
-* property type: `boolean | DocumentHighlightOptions` where `DocumentHighlightOptions` is defined as follows:
+* property type: `boolean | DocumentHighlightOptions | DocumentHighlightRegistrationOptions` where `DocumentHighlightOptions` is defined as follows:
 
 <div class="anchorHolder"><a href="#documentHighlightOptions" name="documentHighlightOptions" class="linkableAnchor"></a></div>
 

--- a/_specifications/lsp/3.18/metaModel/metaModel.json
+++ b/_specifications/lsp/3.18/metaModel/metaModel.json
@@ -8544,6 +8544,10 @@
 							{
 								"kind": "reference",
 								"name": "DocumentHighlightOptions"
+							},
+							{
+								"kind": "reference",
+								"name": "DocumentHighlightRegistrationOptions"
 							}
 						]
 					},


### PR DESCRIPTION
`DocumentHighlightRegistrationOptions` is never been referenced in the specs
