### PR TITLE
fix: `ServerCapability.documentLinkProvider` accepts `DocumentLinkRegistrationOptions` too

### DIFF
--- a/_specifications/lsp/3.17/general/initialize.md
+++ b/_specifications/lsp/3.17/general/initialize.md
@@ -750,7 +750,7 @@ interface ServerCapabilities {
 	/**
 	 * The server provides document link support.
 	 */
-	documentLinkProvider?: DocumentLinkOptions;
+	documentLinkProvider?: DocumentLinkOptions | DocumentLinkRegistrationOptions;
 
 	/**
 	 * The server provides color provider support.

--- a/_specifications/lsp/3.17/language/documentLink.md
+++ b/_specifications/lsp/3.17/language/documentLink.md
@@ -26,7 +26,7 @@ export interface DocumentLinkClientCapabilities {
 
 _Server Capability_:
 * property name (optional): `documentLinkProvider`
-* property type: `DocumentLinkOptions` defined as follows:
+* property type: `DocumentLinkOptions | DocumentLinkRegistrationOptions` defined as follows:
 
 <div class="anchorHolder"><a href="#documentLinkOptions" name="documentLinkOptions" class="linkableAnchor"></a></div>
 

--- a/_specifications/lsp/3.17/metaModel/metaModel.json
+++ b/_specifications/lsp/3.17/metaModel/metaModel.json
@@ -8369,8 +8369,17 @@
 				{
 					"name": "documentLinkProvider",
 					"type": {
-						"kind": "reference",
-						"name": "DocumentLinkOptions"
+						"kind": "or",
+						"items": [
+							{
+								"kind": "reference",
+								"name": "DocumentLinkOptions"
+							},
+							{
+								"kind": "reference",
+								"name": "DocumentLinkRegistrationOptions"
+							}
+						]
 					},
 					"optional": true,
 					"documentation": "The server provides document link support."

--- a/_specifications/lsp/3.18/general/initialize.md
+++ b/_specifications/lsp/3.18/general/initialize.md
@@ -778,7 +778,7 @@ interface ServerCapabilities {
 	/**
 	 * The server provides document link support.
 	 */
-	documentLinkProvider?: DocumentLinkOptions;
+	documentLinkProvider?: DocumentLinkOptions | DocumentLinkRegistrationOptions;
 
 	/**
 	 * The server provides color provider support.

--- a/_specifications/lsp/3.18/language/documentLink.md
+++ b/_specifications/lsp/3.18/language/documentLink.md
@@ -26,7 +26,7 @@ export interface DocumentLinkClientCapabilities {
 
 _Server Capability_:
 * property name (optional): `documentLinkProvider`
-* property type: `DocumentLinkOptions` defined as follows:
+* property type: `DocumentLinkOptions | DocumentLinkRegistrationOptions` defined as follows:
 
 <div class="anchorHolder"><a href="#documentLinkOptions" name="documentLinkOptions" class="linkableAnchor"></a></div>
 

--- a/_specifications/lsp/3.18/metaModel/metaModel.json
+++ b/_specifications/lsp/3.18/metaModel/metaModel.json
@@ -8598,8 +8598,17 @@
 				{
 					"name": "documentLinkProvider",
 					"type": {
-						"kind": "reference",
-						"name": "DocumentLinkOptions"
+						"kind": "or",
+						"items": [
+							{
+								"kind": "reference",
+								"name": "DocumentLinkOptions"
+							},
+							{
+								"kind": "reference",
+								"name": "DocumentLinkRegistrationOptions"
+							}
+						]
 					},
 					"optional": true,
 					"documentation": "The server provides document link support."

--- a/_specifications/specification-3-14.md
+++ b/_specifications/specification-3-14.md
@@ -1861,7 +1861,7 @@ interface ServerCapabilities {
 	/**
 	 * The server provides document link support.
 	 */
-	documentLinkProvider?: DocumentLinkOptions;
+	documentLinkProvider?: DocumentLinkOptions | DocumentLinkRegistrationOptions;
 	/**
 	 * The server provides color provider support.
 	 *

--- a/_specifications/specification-3-15.md
+++ b/_specifications/specification-3-15.md
@@ -1781,7 +1781,7 @@ interface ServerCapabilities {
 	/**
 	 * The server provides document link support.
 	 */
-	documentLinkProvider?: DocumentLinkOptions;
+	documentLinkProvider?: DocumentLinkOptions | DocumentLinkRegistrationOptions;
 
 	/**
 	 * The server provides color provider support.
@@ -5010,7 +5010,7 @@ export interface DocumentLinkClientCapabilities {
 
 _Server Capability_:
 * property name (optional): `documentLinkProvider`
-* property type: `DocumentLinkOptions` defined as follows:
+* property type: `DocumentLinkOptions | DocumentLinkRegistrationOptions` defined as follows:
 
 ```typescript
 export interface DocumentLinkOptions extends WorkDoneProgressOptions {

--- a/_specifications/specification-3-16.md
+++ b/_specifications/specification-3-16.md
@@ -2273,7 +2273,7 @@ interface ServerCapabilities {
 	/**
 	 * The server provides document link support.
 	 */
-	documentLinkProvider?: DocumentLinkOptions;
+	documentLinkProvider?: DocumentLinkOptions | DocumentLinkRegistrationOptions;
 
 	/**
 	 * The server provides color provider support.
@@ -6459,7 +6459,7 @@ export interface DocumentLinkClientCapabilities {
 
 _Server Capability_:
 * property name (optional): `documentLinkProvider`
-* property type: `DocumentLinkOptions` defined as follows:
+* property type: `DocumentLinkOptions | DocumentLinkRegistrationOptions` defined as follows:
 
 ```typescript
 export interface DocumentLinkOptions extends WorkDoneProgressOptions {


### PR DESCRIPTION
`DocumentLinkRegistrationOptions` is never been referenced in the specs