### PR TITLE
correct grammar and consistency in lazy property descriptions

### DIFF
--- a/_specifications/lsp/3.17/language/codeAction.md
+++ b/_specifications/lsp/3.17/language/codeAction.md
@@ -430,7 +430,7 @@ export interface CodeAction {
 The request is sent from the client to the server to resolve additional information for a given code action. This is usually used to compute
 the `edit` property of a code action to avoid its unnecessary computation during the `textDocument/codeAction` request.
 
-Consider the clients announces the `edit` property as a property that can be resolved lazy using the client capability
+Consider the client announcing the `edit` property as a property that can be resolved lazily using the client capability
 
 ```typescript
 textDocument.codeAction.resolveSupport = { properties: ['edit'] };

--- a/_specifications/lsp/3.17/language/inlayHint.md
+++ b/_specifications/lsp/3.17/language/inlayHint.md
@@ -261,7 +261,7 @@ export type InlayHintKind = 1 | 2;
 The request is sent from the client to the server to resolve additional information for a given inlay hint. This is usually used to compute
 the `tooltip`, `location` or `command` properties of an inlay hint's label part to avoid its unnecessary computation during the `textDocument/inlayHint` request.
 
-Consider the clients announces the `label.location` property as a property that can be resolved lazy using the client capability
+Consider the client announcing the `label.location` property as a property that can be resolved lazily using the client capability
 
 ```typescript
 textDocument.inlayHint.resolveSupport = { properties: ['label.location'] };

--- a/_specifications/lsp/3.18/language/codeAction.md
+++ b/_specifications/lsp/3.18/language/codeAction.md
@@ -554,7 +554,7 @@ export interface CodeAction {
 The request is sent from the client to the server to resolve additional information for a given code action. This is usually used to compute
 the `edit` property of a code action to avoid its unnecessary computation during the `textDocument/codeAction` request.
 
-Consider the clients announcing the `edit` property as a property that can be resolved lazily using the client capability.
+Consider the client announcing the `edit` property as a property that can be resolved lazily using the client capability
 
 ```typescript
 textDocument.codeAction.resolveSupport = { properties: ['edit'] };

--- a/_specifications/lsp/3.18/language/inlayHint.md
+++ b/_specifications/lsp/3.18/language/inlayHint.md
@@ -261,7 +261,7 @@ export type InlayHintKind = 1 | 2;
 The request is sent from the client to the server to resolve additional information for a given inlay hint. This is usually used to compute
 the `tooltip`, `location` or `command` properties of an inlay hint's label part to avoid its unnecessary computation during the `textDocument/inlayHint` request.
 
-Consider the client announces the `label.location` property as a property that can be resolved lazily using the client capability
+Consider the client announcing the `label.location` property as a property that can be resolved lazily using the client capability
 
 ```typescript
 textDocument.inlayHint.resolveSupport = { properties: ['label.location'] };

--- a/_specifications/specification-3-16.md
+++ b/_specifications/specification-3-16.md
@@ -6273,7 +6273,7 @@ export interface CodeAction {
 The request is sent from the client to the server to resolve additional information for a given code action. This is usually used to compute
 the `edit` property of a code action to avoid its unnecessary computation during the `textDocument/codeAction` request.
 
-Consider the clients announces the `edit` property as a property that can be resolved lazy using the client capability
+Consider the client announcing the `edit` property as a property that can be resolved lazily using the client capability
 
 ```typescript
 textDocument.codeAction.resolveSupport = { properties: ['edit'] };


### PR DESCRIPTION
- the clients -> the client
- lazy -> lazily
- announces -> announcing