### PR TITLE
Use valid nested placeholder snippet example

### DIFF
--- a/_specifications/lsp/3.18/language/completion.md
+++ b/_specifications/lsp/3.18/language/completion.md
@@ -883,7 +883,7 @@ With tab stops, you can make the editor cursor move inside a snippet. Use `$1`, 
 
 ##### Placeholders
 
-Placeholders are tab stops with values, like `${1:foo}`. The placeholder text will be inserted and selected such that it can be easily changed. Placeholders can be nested, like `${1:another ${2:placeholder}}`.
+Placeholders are tab stops with values, like `${1:foo}`. The placeholder text will be inserted and selected such that it can be easily changed. Placeholders can be nested, like `${1:${2:placeholder}}`.
 
 ##### Choice
 


### PR DESCRIPTION
Closes https://github.com/microsoft/language-server-protocol/issues/2194

I do want to call out that an alternative solution is to allow nested placeholders to consist of multiple nodes, which would require the grammar change from https://github.com/microsoft/language-server-protocol/pull/2032.