### PR TITLE
Add inherited capabilities to JSON metaModel

### DIFF
--- a/_specifications/lsp/3.18/metaModel/metaModel.json
+++ b/_specifications/lsp/3.18/metaModel/metaModel.json
@@ -438,6 +438,8 @@
 				]
 			},
 			"messageDirection": "clientToServer",
+			"clientCapability": "textDocument.callHierarchy",
+			"serverCapability": "callHierarchyProvider",
 			"params": {
 				"kind": "reference",
 				"name": "CallHierarchyIncomingCallsParams"
@@ -472,6 +474,8 @@
 				]
 			},
 			"messageDirection": "clientToServer",
+			"clientCapability": "textDocument.callHierarchy",
+			"serverCapability": "callHierarchyProvider",
 			"params": {
 				"kind": "reference",
 				"name": "CallHierarchyOutgoingCallsParams"
@@ -840,6 +844,8 @@
 				]
 			},
 			"messageDirection": "clientToServer",
+			"clientCapability": "textDocument.typeHierarchy",
+			"serverCapability": "typeHierarchyProvider",
 			"params": {
 				"kind": "reference",
 				"name": "TypeHierarchySupertypesParams"
@@ -874,6 +880,8 @@
 				]
 			},
 			"messageDirection": "clientToServer",
+			"clientCapability": "textDocument.typeHierarchy",
+			"serverCapability": "typeHierarchyProvider",
 			"params": {
 				"kind": "reference",
 				"name": "TypeHierarchySubtypesParams"


### PR DESCRIPTION
Some language bindings rely on the JSON mode to determine whether a given method is callable. It would therefore be helpful to explicitly reference the inherited capability in the JSON definition, rather than mention it only in the human-readable documentation.