### PR TITLE
Queryable References

### DIFF
--- a/_specifications/lsp/3.18/language/references.md
+++ b/_specifications/lsp/3.18/language/references.md
@@ -45,9 +45,71 @@ _Request_:
 <div class="anchorHolder"><a href="#referenceParams" name="referenceParams" class="linkableAnchor"></a></div>
 
 ```typescript
+export namespace ReferenceKind {
+	/**
+	 * Statement with l-value usage of the selected variable.
+	 */
+	export const Lvalue = 1;
+	/**
+	 * Statement with r-value usage of the selected variable.
+	 */
+	export const Rvalue = 2;
+	/**
+	 * Location that constructs a variable of the selected type.
+	 */
+	export const Type = 3;
+	/**
+	 * Location with super-type of the selected type.
+	 */
+	export const SuperType = 4;
+	/**
+	 * Location with sub-type of the selected type.
+	 */
+	export const SubType = 5;
+	/**
+	 * Expression that converts a value to the selected type.
+	 * For example, in Go, 'writer = file' might implicitly convert
+	 * an *os.File to an io.Writer.
+	 */
+	export const TypeConversion = 6;
+	/**
+	 * Implicit reference to the selected identifier.
+	 * For example, in C++, 'Point2D {1, 2}' is shorthand to
+	 * initialize the public fields X and Y, and it might be useful to
+	 * highlight it when finding references to X or Y.
+	 */
+	export const Implicit = 7;
+	/**
+	 * Free variable of the selected code block.
+	 * A variable is "free" if it is referenced from within the
+	 * selected code block but defined outside of it.
+	 */
+	export const FreeVariable = 8;
+	/**
+	 * Function declaration (including anonymous lambdas) that
+	 * satisfies a particular function type (and vice versa).
+	 */
+	export const FunctionDeclaration = 9;
+	/**
+	 * Argument expression that assigns the selected parameter.
+	 * For example, in Go, a query on y 'func f(x, y int)' might
+	 * report the expression 456 in the call f(123, 456).
+	 */
+	export const ArgumentExpression = 10;
+}
+
+export type ReferenceKind = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10;
+```
+
+```typescript
 export interface ReferenceParams extends TextDocumentPositionParams,
 	WorkDoneProgressParams, PartialResultParams {
 	context: ReferenceContext;
+	/**
+	 * The requested reference kinds to filter by.
+	 * Clients may send an empty array to request all kinds of references.
+	 */
+	referenceKind?: ReferenceKind[];
 }
 ```
 
@@ -62,6 +124,6 @@ export interface ReferenceContext {
 }
 ```
 _Response_:
-* result: [`Location`](#location)[] \| `null`
-* partial result: [`Location`](#location)[]
+* result: [`Reference`](#reference)[] \| `null`
+* partial result: [`Reference`](#reference)[]
 * error: code and message set in case an exception happens during the reference request.

--- a/_specifications/lsp/3.18/language/references.md
+++ b/_specifications/lsp/3.18/language/references.md
@@ -49,11 +49,11 @@ export namespace ReferenceKind {
 	/**
 	 * Statement with l-value usage of the selected variable.
 	 */
-	export const Lvalue = 1;
+	export const Write = 1;
 	/**
 	 * Statement with r-value usage of the selected variable.
 	 */
-	export const Rvalue = 2;
+	export const Read = 2;
 	/**
 	 * Location that constructs a variable of the selected type.
 	 */

--- a/_specifications/lsp/3.18/metaModel/metaModel.json
+++ b/_specifications/lsp/3.18/metaModel/metaModel.json
@@ -5543,6 +5543,23 @@
 						"kind": "reference",
 						"name": "ReferenceContext"
 					}
+				},
+				{
+					"name": "referenceKind",
+					"kind": "or",
+					"items": [
+						{
+							"kind": "array",
+							"element": {
+								"kind": "reference",
+								"name": "ReferenceKind"
+							}
+						},
+						{
+							"kind": "base",
+							"name": "null"
+						}
+					]
 				}
 			],
 			"extends": [
@@ -16077,6 +16094,94 @@
 				"kind": "base",
 				"name": "string"
 			}
+		},
+		{
+			"name": "ReferenceKind",
+			"type": {
+				"kind": "base",
+				"name": "uinteger"
+			},
+			"values": [
+				{
+					"name": "Lvalue",
+					"value": 1,
+					"documentation": "Statement with l-value usage of the selected variable.",
+					"since": "3.18"
+				},
+				{
+					"name": "Rvalue",
+					"value": 2,
+					"documentation": "Statement with r-value usage of the selected variable.",
+					"since": "3.18"
+				},
+				{
+					"name": "Type",
+					"value": 3,
+					"documentation": "Location that constructs a variable of the selected type.",
+					"since": "3.18"
+				},
+				{
+					"name": "SuperType",
+					"value": 4,
+					"documentation": "Location with super-type of the selected type.",
+					"since": "3.18"
+				},
+				{
+					"name": "SubType",
+					"value": 5,
+					"documentation": "Location with sub-type of the selected type.",
+					"since": "3.18"
+				},
+				{
+					"name": "TypeConversion",
+					"value": 6,
+					"documentation": "Expression that converts a value to the selected type.\n For example, in Go, 'writer = file' might implicitly convert\n an *os.File to an io.Writer.",
+					"since": "3.18"
+				},
+				{
+					"name": "Implicit",
+					"value": 7,
+					"documentation": "Implicit reference to the selected identifier.\n For example, in C++, 'Point2D {1, 2}' is shorthand to\n initialize the public fields X and Y, and it might be useful to\n highlight it when finding references to X or Y.",
+					"since": "3.18"
+				},
+				{
+					"name": "FreeVariable",
+					"value": 8,
+					"documentation": "Free variable of the selected code block.\n A variable is 'free' if it is referenced from within the\n selected code block but defined outside of it.",
+					"since": "3.18"
+				},
+				{
+					"name": "FunctionDeclaration",
+					"value": 9,
+					"documentation": "Function declaration (including anonymous lambdas) that\n satisfies a particular function type (and vice versa).",
+					"since": "3.18"
+				},
+				{
+					"name": "ArgumentExpression",
+					"value": 10,
+					"documentation": "Argument expression that assigns the selected parameter.\n For example, in Go, a query on y 'func f(x, y int)' might\n report the expression 456 in the call f(123, 456).",
+					"since": "3.18"
+				}
+			]
+		},
+		{
+			"name": "Reference",
+			"properties": [
+				{
+					"name": "location",
+					"type": {
+						"kind": "base",
+						"name": "Location"
+					}
+				},
+				{
+					"name": "referenceKind",
+					"type": {
+						"kind": "reference",
+						"name": "ReferenceKind"
+					}
+				}
+			]
 		}
 	]
 }

--- a/_specifications/lsp/3.18/metaModel/metaModel.json
+++ b/_specifications/lsp/3.18/metaModel/metaModel.json
@@ -16103,13 +16103,13 @@
 			},
 			"values": [
 				{
-					"name": "Lvalue",
+					"name": "Write",
 					"value": 1,
 					"documentation": "Statement with l-value usage of the selected variable.",
 					"since": "3.18"
 				},
 				{
-					"name": "Rvalue",
+					"name": "Read",
 					"value": 2,
 					"documentation": "Statement with r-value usage of the selected variable.",
 					"since": "3.18"

--- a/_specifications/lsp/3.18/types/reference.md
+++ b/_specifications/lsp/3.18/types/reference.md
@@ -1,0 +1,9 @@
+#### <a href="#reference" name="reference" class="anchor">Reference</a>
+
+Represents a reference inside a workspace. A reference has a location and a specific kind.
+```typescript
+interface Reference {
+	location: Location;
+	referenceKind: ReferenceKind;
+}
+```

--- a/_specifications/lsp/3.18/types/reference.md
+++ b/_specifications/lsp/3.18/types/reference.md
@@ -4,6 +4,6 @@ Represents a reference inside a workspace. A reference has a location and a spec
 ```typescript
 interface Reference {
 	location: Location;
-	referenceKind: ReferenceKind;
+	referenceKind: ReferenceKind[];
 }
 ```


### PR DESCRIPTION
A proposal for https://github.com/microsoft/language-server-protocol/issues/1911. Introduced `Reference` as new response type in the method `references`. Extended `ReferenceParams` with array of reference kinds to filter by.