### PR TITLE
Fixes #2080: deprecate the top-level activeParameter property or update the documentation to clearly explain why there are two of them

### DIFF
--- a/_specifications/lsp/3.17/language/signatureHelp.md
+++ b/_specifications/lsp/3.17/language/signatureHelp.md
@@ -221,9 +221,9 @@ export interface SignatureHelp {
 	 * lies outside the range of `signatures[activeSignature].parameters`
 	 * defaults to 0 if the active signature has parameters. If
 	 * the active signature has no parameters it is ignored.
-	 * In future version of the protocol this property might become
-	 * mandatory to better express the active parameter if the
-	 * active signature does have any.
+	 *
+	 * Since version 3.16.0 the `SignatureInformation` itself provides a
+	 * `activeParameter` property and it should be used instead of this one.
 	 */
 	activeParameter?: uinteger;
 }

--- a/_specifications/lsp/3.18/language/signatureHelp.md
+++ b/_specifications/lsp/3.18/language/signatureHelp.md
@@ -240,9 +240,8 @@ export interface SignatureHelp {
 	 *
 	 * If the active signature has no parameters, it is ignored.
 	 *
-	 * In future versions of the protocol this property might become
-	 * mandatory (but still nullable) to better express the active parameter if
-	 * the active signature does have any.
+	 * Since version 3.16.0 the `SignatureInformation` itself provides a
+	 * `activeParameter` property and it should be used instead of this one.
 	 */
 	activeParameter?: uinteger | null;
 }


### PR DESCRIPTION
Fixes #2080