### PR TITLE
Fix typo in metaSchema

### DIFF
--- a/_specifications/lsp/3.18/metaModel/metaModel.schema.json
+++ b/_specifications/lsp/3.18/metaModel/metaModel.schema.json
@@ -3,7 +3,7 @@
   "definitions": {
     "AndType": {
       "additionalProperties": false,
-      "description": "Represents an `and`type (e.g. TextDocumentParams & WorkDoneProgressParams`).",
+      "description": "Represents an `and` type (e.g. TextDocumentParams & WorkDoneProgressParams`).",
       "properties": {
         "items": {
           "items": {

--- a/_specifications/lsp/3.18/metaModel/metaModel.ts
+++ b/_specifications/lsp/3.18/metaModel/metaModel.ts
@@ -57,7 +57,7 @@ export type MapType = {
 };
 
 /**
- * Represents an `and`type
+ * Represents an `and` type
  * (e.g. TextDocumentParams & WorkDoneProgressParams`).
  */
 export type AndType = {


### PR DESCRIPTION
I could make the change to the 3.17 version as well, but I'm unsure if that is a fully locked spec that cannot be changed like this?