### PR TITLE
Add Buf Language Server

### DIFF
--- a/_implementors/servers.md
+++ b/_implementors/servers.md
@@ -197,6 +197,7 @@ index: 1
 | [PromQL](https://prometheus.io/docs/prometheus/latest/querying/basics/) | [Tobias Guggenmos](https://github.com/slrtbtfs) | [promql-langserver](https://github.com/prometheus-community/promql-langserver) | [Go](https://golang.org/) |
 | [Protocol Buffers](https://protobuf.dev/) | [coder3101](https://github.com/coder3101) | [protols](https://github.com/coder3101/protols) | Rust |
 | [Protocol Buffers](https://protobuf.dev/) | [lasorda](https://github.com/lasorda) | [protobuf-language-server](https://github.com/lasorda/protobuf-language-server) | Go |
+| [Protocol Buffers](https://protobuf.dev/) | [Buf](https://github.com/bufbuild) | [Buf Language Server](https://github.com/bufbuild/buf) | Go |
 | PureScript | [Nicholas Wolverson](https://github.com/nwolverson) | [purescript-language-server](https://github.com/nwolverson/purescript-language-server) | PureScript |
 | Puppet| [Lingua Pupuli](https://github.com/lingua-pupuli) | [puppet language server](https://github.com/lingua-pupuli/puppet-editor-services) | Ruby |
 | Python | [astral-sh](https://astral.sh/) | [ty](https://github.com/astral-sh/ty) | Rust |


### PR DESCRIPTION
For protobuf - under the `buf lsp serve` command.