### PR TITLE
Compute additional information (reference tag) about the kind of access to a referenced item. 

### DIFF
--- a/_specifications/lsp/3.18/language/callHierarchy.md
+++ b/_specifications/lsp/3.18/language/callHierarchy.md
@@ -25,7 +25,8 @@ interface CallHierarchyClientCapabilities {
 	dynamicRegistration?: boolean;
 
     /**
-     * Determines whether the client supports reference tags.
+     * Determines whether the client supports reference tags. If the value is missing,
+     * the server assumes that the client does not support reference tags.
      * @since 3.18.0
      */
     referencesItemSupport?: boolean;

--- a/_specifications/lsp/3.18/language/callHierarchy.md
+++ b/_specifications/lsp/3.18/language/callHierarchy.md
@@ -71,11 +71,11 @@ _Response_:
 ```typescript
 export namespace ReferenceTag {
 	/**
-	 * Statement with r-value usage of the referenced variable.
+	 * Determines a read access to the referenced symbol.
 	 */
 	export const Read = 1;
 	/**
-	 * Statement with l-value usage of the referenced variable.
+	 * Determines a write access to the referenced symbol.
 	 */
 	export const Write = 2;
 }

--- a/_specifications/lsp/3.18/language/callHierarchy.md
+++ b/_specifications/lsp/3.18/language/callHierarchy.md
@@ -28,7 +28,7 @@ interface CallHierarchyClientCapabilities {
      * Determines whether the client supports reference tags.
      * @since 3.18.0
      */
-    referenceItemSupport?: boolean;
+    referencesItemSupport?: boolean;
 }
 ```
 

--- a/_specifications/lsp/3.18/language/callHierarchy.md
+++ b/_specifications/lsp/3.18/language/callHierarchy.md
@@ -29,7 +29,7 @@ interface CallHierarchyClientCapabilities {
      * the server assumes that the client does not support reference tags.
      * @since 3.18.0
      */
-    referencesItemSupport?: boolean;
+    referenceTagsSupport?: boolean;
 }
 ```
 

--- a/_specifications/lsp/3.18/language/callHierarchy.md
+++ b/_specifications/lsp/3.18/language/callHierarchy.md
@@ -69,6 +69,19 @@ _Response_:
 <div class="anchorHolder"><a href="#callHierarchyItem" name="callHierarchyItem" class="linkableAnchor"></a></div>
 
 ```typescript
+export namespace ReferenceTag {
+	/**
+	 * Statement with r-value usage of the referenced variable.
+	 */
+	export const Read = 1;
+	/**
+	 * Statement with l-value usage of the referenced variable.
+	 */
+	export const Write = 2;
+}
+
+export type ReferenceTag = 1 | 2;
+
 export interface CallHierarchyItem {
 	/**
 	 * The name of this item.
@@ -84,6 +97,11 @@ export interface CallHierarchyItem {
 	 * Tags for this item.
 	 */
 	tags?: SymbolTag[];
+
+	/**
+	 * Reference tags of this item.
+	 */
+	referenceTags?: ReferenceTag[];
 
 	/**
 	 * More detail for this item, e.g. the signature of a function.

--- a/_specifications/lsp/3.18/language/callHierarchy.md
+++ b/_specifications/lsp/3.18/language/callHierarchy.md
@@ -23,6 +23,19 @@ interface CallHierarchyClientCapabilities {
 	 * capability as well.
 	 */
 	dynamicRegistration?: boolean;
+
+    /**
+     * Whether client supports reference tags.
+     * Clients supporting tags have to handle unknown tags gracefully.
+     *
+     * @since 3.18.0
+     */
+    tagSupport?: {
+        /**
+         * The tags supported by the client.
+         */
+        valueSet: ReferenceTag[];
+    };
 }
 ```
 

--- a/_specifications/lsp/3.18/language/callHierarchy.md
+++ b/_specifications/lsp/3.18/language/callHierarchy.md
@@ -25,17 +25,10 @@ interface CallHierarchyClientCapabilities {
 	dynamicRegistration?: boolean;
 
     /**
-     * Whether client supports reference tags.
-     * Clients supporting tags have to handle unknown tags gracefully.
-     *
+     * Determines whether the client supports reference tags.
      * @since 3.18.0
      */
-    tagSupport?: {
-        /**
-         * The tags supported by the client.
-         */
-        valueSet: ReferenceTag[];
-    };
+    referenceItemSupport?: boolean;
 }
 ```
 

--- a/_specifications/lsp/3.18/language/references.md
+++ b/_specifications/lsp/3.18/language/references.md
@@ -14,6 +14,19 @@ export interface ReferenceClientCapabilities {
 	 * Whether references supports dynamic registration.
 	 */
 	dynamicRegistration?: boolean;
+
+    /**
+     * Determines whether the client supports reference tags, and if so, which ones exactly.
+     * Clients supporting tags have to handle unknown tags gracefully.
+     *
+     * @since 3.18.0
+     */
+    tagSupport?: {
+        /**
+         * The tags supported by the client.
+         */
+        valueSet: ReferenceTag[];
+    };
 }
 ```
 
@@ -62,6 +75,6 @@ export interface ReferenceContext {
 }
 ```
 _Response_:
-* result: [`Location`](#location)[] \| `null`
-* partial result: [`Location`](#location)[]
+* result: [`Location`](#location)[] \| [`Reference`](#reference)[] \| `null`
+* partial result: [`Location`](#location)[] \| [`Reference`](#reference)[]
 * error: code and message set in case an exception happens during the reference request.

--- a/_specifications/lsp/3.18/language/references.md
+++ b/_specifications/lsp/3.18/language/references.md
@@ -16,17 +16,10 @@ export interface ReferenceClientCapabilities {
 	dynamicRegistration?: boolean;
 
     /**
-     * Determines whether the client supports reference tags, and if so, which ones exactly.
-     * Clients supporting tags have to handle unknown tags gracefully.
-     *
+     * Determines whether the client supports reference tags.
      * @since 3.18.0
      */
-    tagSupport?: {
-        /**
-         * The tags supported by the client.
-         */
-        valueSet: ReferenceTag[];
-    };
+    referenceItemSupport?: boolean;
 }
 ```
 

--- a/_specifications/lsp/3.18/language/references.md
+++ b/_specifications/lsp/3.18/language/references.md
@@ -19,7 +19,7 @@ export interface ReferenceClientCapabilities {
      * Determines whether the client supports reference tags.
      * @since 3.18.0
      */
-    referenceItemSupport?: boolean;
+    referencesItemSupport?: boolean;
 }
 ```
 

--- a/_specifications/lsp/3.18/language/references.md
+++ b/_specifications/lsp/3.18/language/references.md
@@ -10,10 +10,10 @@ _Client Capability_:
 
 ```typescript
 export interface ReferenceClientCapabilities {
-	/**
-	 * Whether references supports dynamic registration.
-	 */
-	dynamicRegistration?: boolean;
+    /**
+     * Whether references supports dynamic registration.
+     */
+    dynamicRegistration?: boolean;
 
     /**
      * Determines whether the client supports and prefers Reference items instead

--- a/_specifications/lsp/3.18/language/references.md
+++ b/_specifications/lsp/3.18/language/references.md
@@ -16,10 +16,12 @@ export interface ReferenceClientCapabilities {
 	dynamicRegistration?: boolean;
 
     /**
-     * Determines whether the client supports reference tags.
+     * Determines whether the client supports and prefers Reference items instead
+     * of Location items. If this value is missing, the server assumes that the
+     * client accepts Location items as defined in earlier versions of the protocol.
      * @since 3.18.0
      */
-    referencesItemSupport?: boolean;
+    referencesTagSupport?: boolean;
 }
 ```
 

--- a/_specifications/lsp/3.18/language/references.md
+++ b/_specifications/lsp/3.18/language/references.md
@@ -21,7 +21,7 @@ export interface ReferenceClientCapabilities {
      * client accepts Location items as defined in earlier versions of the protocol.
      * @since 3.18.0
      */
-    referencesTagSupport?: boolean;
+    referenceItemsSupport?: boolean;
 }
 ```
 

--- a/_specifications/lsp/3.18/metaModel/metaModel.json
+++ b/_specifications/lsp/3.18/metaModel/metaModel.json
@@ -3044,6 +3044,18 @@
 					"documentation": "Tags for this item."
 				},
 				{
+					"name": "referenceTags",
+					"type": {
+						"kind": "array",
+						"element": {
+							"kind": "reference",
+							"name": "ReferenceTag"
+						}
+					},
+					"optional": true,
+					"documentation": "Reference tags for this item, i.e. determines the operations on the referenced symbol, read, write or both"
+				},
+				{
 					"name": "detail",
 					"type": {
 						"kind": "base",

--- a/_specifications/lsp/3.18/metaModel/metaModel.json
+++ b/_specifications/lsp/3.18/metaModel/metaModel.json
@@ -12736,13 +12736,13 @@
 					"documentation": "Whether references supports dynamic registration."
 				},
 				{
-					"name": "tagSupport",
+					"name": "referenceItemSupport",
 					"type": {
 						"kind": "reference",
-						"name": "ClientReferenceTagOptions"
+						"name": "ClientReferenceTagSupportOption"
 					},
 					"optional": true,
-					"documentation": "Determines whether the client supports reference tags, and if so, which ones exactly.\nClients supporting tags have to handle unknown tags gracefully.",
+					"documentation": "Determines whether the client supports reference tags.",
 					"since": "3.18.0"
 				}
 			],
@@ -13177,13 +13177,13 @@
 					"documentation": "Whether implementation supports dynamic registration. If this is set to `true`\nthe client supports the new `(TextDocumentRegistrationOptions & StaticRegistrationOptions)`\nreturn value for the corresponding server capability as well."
 				},
 				{
-					"name": "tagSupport",
+					"name": "referenceItemSupport",
 					"type": {
 						"kind": "reference",
-						"name": "ClientReferenceTagOptions"
+						"name": "ClientReferenceTagSupportOption"
 					},
 					"optional": true,
-					"documentation": "Determines whether the client supports reference tags, and if so, which ones exactly.\nClients supporting tags have to handle unknown tags gracefully.",
+					"documentation": "Determines whether the client supports reference tags.",
 					"since": "3.18.0"
 				}
 			],

--- a/_specifications/lsp/3.18/metaModel/metaModel.json
+++ b/_specifications/lsp/3.18/metaModel/metaModel.json
@@ -12736,13 +12736,13 @@
 					"documentation": "Whether references supports dynamic registration."
 				},
 				{
-					"name": "referencesItemSupport",
+					"name": "referenceItemsSupport",
 					"type": {
 						"kind": "reference",
 						"name": "ClientReferenceTagSupportOption"
 					},
 					"optional": true,
-					"documentation": "Determines whether the client supports reference tags.",
+					"documentation": "Determines whether the client supports and prefers Reference items instead\nof Location items. If this value is missing, the server assumes that the\nclient accepts Location items as defined in earlier versions of the protocol.",
 					"since": "3.18.0"
 				}
 			],
@@ -13177,7 +13177,7 @@
 					"documentation": "Whether implementation supports dynamic registration. If this is set to `true`\nthe client supports the new `(TextDocumentRegistrationOptions & StaticRegistrationOptions)`\nreturn value for the corresponding server capability as well."
 				},
 				{
-					"name": "referencesItemSupport",
+					"name": "referenceTagsSupport",
 					"type": {
 						"kind": "reference",
 						"name": "ClientReferenceTagSupportOption"

--- a/_specifications/lsp/3.18/metaModel/metaModel.json
+++ b/_specifications/lsp/3.18/metaModel/metaModel.json
@@ -12736,7 +12736,7 @@
 					"documentation": "Whether references supports dynamic registration."
 				},
 				{
-					"name": "referenceItemSupport",
+					"name": "referencesItemSupport",
 					"type": {
 						"kind": "reference",
 						"name": "ClientReferenceTagSupportOption"
@@ -13177,7 +13177,7 @@
 					"documentation": "Whether implementation supports dynamic registration. If this is set to `true`\nthe client supports the new `(TextDocumentRegistrationOptions & StaticRegistrationOptions)`\nreturn value for the corresponding server capability as well."
 				},
 				{
-					"name": "referenceItemSupport",
+					"name": "referencesItemSupport",
 					"type": {
 						"kind": "reference",
 						"name": "ClientReferenceTagSupportOption"

--- a/_specifications/lsp/3.18/metaModel/metaModel.json
+++ b/_specifications/lsp/3.18/metaModel/metaModel.json
@@ -14586,6 +14586,27 @@
 			"since": "3.16"
 		},
 		{
+			"name": "RferenceTag",
+			"type": {
+				"kind": "base",
+				"name": "uinteger"
+			},
+			"values": [
+				{
+					"name": "Read",
+					"value": 1,
+					"documentation": "Determines a read access to the referenced symbol."
+				},
+				{
+					"name": "Write",
+					"value": 2,
+					"documentation": "Determines a write access to the referenced symbol."
+				}
+			],
+			"documentation": "Reference tags are extra annotations that provide additional information about references.\n\n@since 3.18",
+			"since": "3.18"
+		},
+		{
 			"name": "UniquenessLevel",
 			"type": {
 				"kind": "base",

--- a/_specifications/lsp/3.18/metaModel/metaModel.json
+++ b/_specifications/lsp/3.18/metaModel/metaModel.json
@@ -12738,8 +12738,8 @@
 				{
 					"name": "referenceItemsSupport",
 					"type": {
-						"kind": "reference",
-						"name": "ClientReferenceTagSupportOption"
+						"kind": "base",
+						"name": "boolean"
 					},
 					"optional": true,
 					"documentation": "Determines whether the client supports and prefers Reference items instead\nof Location items. If this value is missing, the server assumes that the\nclient accepts Location items as defined in earlier versions of the protocol.",
@@ -13179,8 +13179,8 @@
 				{
 					"name": "referenceTagsSupport",
 					"type": {
-						"kind": "reference",
-						"name": "ClientReferenceTagSupportOption"
+						"kind": "base",
+						"name": "boolean"
 					},
 					"optional": true,
 					"documentation": "Determines whether the client supports reference tags.",
@@ -14606,7 +14606,7 @@
 			"since": "3.16"
 		},
 		{
-			"name": "RferenceTag",
+			"name": "ReferenceTag",
 			"type": {
 				"kind": "base",
 				"name": "uinteger"

--- a/_specifications/lsp/3.18/metaModel/metaModel.json
+++ b/_specifications/lsp/3.18/metaModel/metaModel.json
@@ -12734,6 +12734,16 @@
 					},
 					"optional": true,
 					"documentation": "Whether references supports dynamic registration."
+				},
+				{
+					"name": "tagSupport",
+					"type": {
+						"kind": "reference",
+						"name": "ClientReferenceTagOptions"
+					},
+					"optional": true,
+					"documentation": "Determines whether the client supports reference tags, and if so, which ones exactly.\nClients supporting tags have to handle unknown tags gracefully.",
+					"since": "3.18.0"
 				}
 			],
 			"documentation": "Client Capabilities for a {@link ReferencesRequest}."
@@ -13165,6 +13175,16 @@
 					},
 					"optional": true,
 					"documentation": "Whether implementation supports dynamic registration. If this is set to `true`\nthe client supports the new `(TextDocumentRegistrationOptions & StaticRegistrationOptions)`\nreturn value for the corresponding server capability as well."
+				},
+				{
+					"name": "tagSupport",
+					"type": {
+						"kind": "reference",
+						"name": "ClientReferenceTagOptions"
+					},
+					"optional": true,
+					"documentation": "Determines whether the client supports reference tags, and if so, which ones exactly.\nClients supporting tags have to handle unknown tags gracefully.",
+					"since": "3.18.0"
 				}
 			],
 			"documentation": "@since 3.16.0",

--- a/_specifications/lsp/3.18/specification.md
+++ b/_specifications/lsp/3.18/specification.md
@@ -457,6 +457,7 @@ There are quite some JSON structures that are shared between different requests 
 {% include_relative types/textEditArray.md %}
 {% include_relative types/textDocumentEdit.md %}
 {% include_relative types/location.md %}
+{% include_relative types/reference.md %}
 {% include_relative types/locationLink.md %}
 {% include_relative types/diagnostic.md %}
 {% include_relative types/command.md %}

--- a/_specifications/lsp/3.18/types/reference.md
+++ b/_specifications/lsp/3.18/types/reference.md
@@ -1,0 +1,9 @@
+#### <a href="#reference" name="reference" class="anchor">Reference</a>
+
+Represents a reference inside the workspace. A reference has a location and can have one or more tags.
+```typescript
+interface Reference {
+	location: Location;
+	referenceTags: ReferenceTag[];
+}
+```

--- a/_specifications/lsp/3.18/types/reference.md
+++ b/_specifications/lsp/3.18/types/reference.md
@@ -1,4 +1,4 @@
-#### <a href="#textDocument_reference" name="textDocument_reference" class="anchor">Reference</a>
+#### <a href="#reference" name="reference" class="anchor">Reference</a>
 
 > *Since version 3.18.0*
 

--- a/_specifications/lsp/3.18/types/reference.md
+++ b/_specifications/lsp/3.18/types/reference.md
@@ -4,6 +4,6 @@ Represents a reference inside the workspace. A reference has a location and can 
 ```typescript
 interface Reference {
 	location: Location;
-	referenceTags: ReferenceTag[];
+	referenceTags?: ReferenceTag[];
 }
 ```

--- a/_specifications/lsp/3.18/types/reference.md
+++ b/_specifications/lsp/3.18/types/reference.md
@@ -1,9 +1,20 @@
-#### <a href="#reference" name="reference" class="anchor">Reference</a>
+#### <a href="#textDocument_reference" name="textDocument_reference" class="anchor">Reference</a>
+
+> *Since version 3.18.0*
 
 Represents a reference inside the workspace. A reference has a location and can have one or more tags.
+
 ```typescript
 interface Reference {
-	location: Location;
-	referenceTags?: ReferenceTag[];
+    /**
+     * The location of this reference.
+     * @since 3.18.0
+     */
+    location: Location;
+    /**
+     * Optional, one or more tags describing this reference.
+     * @since 3.18.0
+     */
+    referenceTags?: ReferenceTag[];
 }
 ```


### PR DESCRIPTION
Compute additional information about the kind of access in the following methods:
- `textDocument.callHierarchy`
- `textDocument.references` 

The type of access indicates whether the referenced object is being written to or read from.

Related [PR 172462](https://github.com/llvm/llvm-project/pull/172462)