### PR TITLE
Add `null` to return types

### DIFF
--- a/_specifications/lsp/3.18/language/colorPresentation.md
+++ b/_specifications/lsp/3.18/language/colorPresentation.md
@@ -36,7 +36,7 @@ interface ColorPresentationParams extends WorkDoneProgressParams,
 ```
 
 _Response_:
-* result: `ColorPresentation[]` defined as follows:
+* result: `ColorPresentation[] | null`, where `ColorPresentation` is defined as follows:
 
 <div class="anchorHolder"><a href="#colorPresentation" name="colorPresentation" class="linkableAnchor"></a></div>
 

--- a/_specifications/lsp/3.18/language/documentColor.md
+++ b/_specifications/lsp/3.18/language/documentColor.md
@@ -63,7 +63,7 @@ interface DocumentColorParams extends WorkDoneProgressParams,
 ```
 
 _Response_:
-* result: `ColorInformation[]` defined as follows:
+* result: `ColorInformation[] | null`, where `ColorInformation` is defined as follows:
 
 <div class="anchorHolder"><a href="#colorInformation" name="colorInformation" class="linkableAnchor"></a></div>
 


### PR DESCRIPTION
After https://github.com/microsoft/vscode-languageserver-node/pull/1691 these methods are typed as potentially returning `null`. Updating the documentation to reflect this.