### PR TITLE
add ClientDiagnosticsTagOptions to the 3.18 spec document

### DIFF
--- a/_specifications/lsp/3.18/language/pullDiagnostics.md
+++ b/_specifications/lsp/3.18/language/pullDiagnostics.md
@@ -64,6 +64,18 @@ export interface DiagnosticClientCapabilities {
 }
 ```
 
+```typescript
+/**
+ * @since 3.18.0
+ */
+export interface ClientDiagnosticsTagOptions {
+	/**
+	 * The tags supported by the client.
+	 */
+	valueSet: DiagnosticTag[];
+}
+```
+
 _Server Capability_:
 * property name (optional): `diagnosticProvider`
 * property type: `DiagnosticOptions` defined as follows:


### PR DESCRIPTION
`ClientDiagnosticsTagOptions` is defined in the v3.18 metamodel but not in the specification document.

https://github.com/microsoft/language-server-protocol/blob/gh-pages/_specifications/lsp/3.18/metaModel/metaModel.json#L14148-L14165