### PR TITLE
Document the `starpls` Bazel/Starlark language server

### DIFF
--- a/_implementors/servers.md
+++ b/_implementors/servers.md
@@ -39,6 +39,7 @@ index: 1
 | Bash | [Mads Hartmann](https://github.com/mads-hartmann/) | [Bash Language Server](https://github.com/mads-hartmann/bash-language-server) | TypeScript |
 | Batch | [RechInformatica](https://github.com/RechInformatica) | [rech-editor-batch](https://github.com/RechInformatica/rech-editor-batch/tree/master/src/lsp) | TypeScript |
 | [Bazel](https://bazel.build/) | [cameron-martin](https://github.com/cameron-martin) | [bazel-lsp](https://github.com/cameron-martin/bazel-lsp) | Rust |
+| [Bazel](https://bazel.build/) | [withered-magic](https://github.com/withered-magic) | [starpls](https://github.com/withered-magic/starpls) | Rust |
 | [Bicep](https://github.com/azure/bicep) | MS | [Bicep](https://github.com/azure/bicep) | C# |
 | [BitBake](https://docs.yoctoproject.org/bitbake/) | [The Yocto Project](https://github.com/yoctoproject) | [BitBake Language Server](https://github.com/yoctoproject/vscode-bitbake/tree/staging/server) | TypeScript |
 | BrightScript/BrighterScript | [RokuCommunity](https://github.com/RokuCommunity) | [brighterscript](https://github.com/rokucommunity/brighterscript) | TypeScript |


### PR DESCRIPTION
[starpls](https://github.com/withered-magic/starpls) is the de-facto Starlark language server across the Bazel/Buck2 ecosystem and is recommended/bundled by the canonical editor integrations for those toolchains:

- **Bazel's official VS Code extension** (`bazelbuild/vscode-bazel`, ~480 stars, maintained by the Bazel project itself) lists `starpls` as one of two recommended Starlark language servers in its README: https://github.com/bazelbuild/vscode-bazel#using-a-language-server-experimental
- **`neovim/nvim-lspconfig`** ships a built-in `starpls` server config (the canonical Neovim LSP registry, ~11k stars): https://github.com/neovim/nvim-lspconfig/blob/master/lua/lspconfig/configs/starpls.lua
- **Zed's Starlark extension** (`zaucy/zed-starlark`) uses `starpls` as its *default* LSP for `.bzl`/`BUILD`/`WORKSPACE` files: https://github.com/zaucy/zed-starlark#configure-the-lsp
- Built on the rust-analyzer architecture, providing Bazel-specific functionality (rule attribute inference, `ctx` autocompletion, etc.) that the older Facebook-derived Starlark LSP lacks.