### PR TITLE
docs: fix InlineValueParams context description

### DIFF
--- a/_specifications/lsp/3.18/metaModel/metaModel.json
+++ b/_specifications/lsp/3.18/metaModel/metaModel.json
@@ -3937,7 +3937,7 @@
 						"kind": "reference",
 						"name": "InlineValueContext"
 					},
-					"documentation": "Additional information about the context in which inline values information was\nrequested.\t */"
+					"documentation": "Additional information about the context in which inline values information was\nrequested."
 				}
 			],
 			"mixins": [


### PR DESCRIPTION
## Summary
- Remove the stray `*/` suffix from the 3.18 `InlineValueParams.context` documentation in the LSP meta model.
- Match the generated inline value docs, which already show the clean sentence.

Fixes #2270.

## Testing
- `python -m json.tool _specifications\lsp\3.18\metaModel\metaModel.json`
- `git diff --check`
- `rg -n "requested\.\t \*/|requested\.\\t \*/|Additional information about the context in which inline values information was" _specifications\lsp\3.18\metaModel\metaModel.json`

## AI disclosure
This pull request was prepared with assistance from OpenAI Codex.