### PR TITLE
Update LSP specification version to 3.18

### DIFF
--- a/index.html
+++ b/index.html
@@ -94,7 +94,7 @@ layout: default
             <h1 class="text-center"><i class="fas fa-book" aria-hidden="true"></i></h1>
             <a href='{{ "/specifications/specification-current" | prepend: site.baseurl }}'><h3 class="text-center">Specification</h3></a>
             <p>
-                The latest version of the LSP specification is version 3.17. There is now also a specification for the upcoming language server index format (LSIF).
+                The latest version of the LSP specification is version 3.18. There is now also a specification for the upcoming language server index format (LSIF).
             </p>
         </div>
         <div class="col-lg-4">


### PR DESCRIPTION
Update the displayed version of the LSP specification in the documentation to reflect the latest version, 3.18.