### PR TITLE
Add perl-lsp to the Perl language servers list

### DIFF
--- a/_implementors/servers.md
+++ b/_implementors/servers.md
@@ -184,6 +184,7 @@ index: 1
 | Perl | GRICHTER | [Perl::LanguageServer](https://metacpan.org/pod/Perl::LanguageServer) | Perl |
 | Perl | [Marc Reisner](https://github.com/FractalBoy) | [PLS](https://github.com/FractalBoy/perl-language-server)| Perl |
 | Perl | [Brian Scannell](https://github.com/bscan) | [Perl Navigator](https://github.com/bscan/PerlNavigator)| Perl |
+| Perl | [Veesh Goldman](https://github.com/rabbiveesh) | [perl-lsp](https://github.com/tree-sitter-perl/perl-tree-sitter-lsp) | Rust |
 | Pest | [Pest Maintainers](https://github.com/orgs/pest-parser/teams/pest-ide-tools) | [Pest IDE Tools](https://github.com/pest-parser/pest-ide-tools) | Rust |
 | Crane **PHP** | [HvyIndustries](https://github.com/HvyIndustries) | [crane](https://github.com/HvyIndustries/crane) | TypeScript |
 | PHP | [Ben Mewburn](https://github.com/bmewburn) | [intelephense](https://github.com/bmewburn/vscode-intelephense) | TypeScript |


### PR DESCRIPTION
Adds [perl-lsp](https://github.com/tree-sitter-perl/perl-tree-sitter-lsp) to the Perl section of the implementors list.

perl-lsp is a Perl language server written in Rust, built on tree-sitter-perl and tower-lsp. It provides type inference (no annotations needed), framework-aware intelligence (Moo/Moose, Mojolicious, DBIx::Class), and cross-file resolution, alongside the usual completion / hover / goto-def / references / rename / diagnostics. Installable via `cargo install perl-lsp`.