### PR TITLE
Update meta model version to 3.18.0

### DIFF
--- a/_specifications/lsp/3.18/metaModel/metaModel.json
+++ b/_specifications/lsp/3.18/metaModel/metaModel.json
@@ -1,6 +1,6 @@
 {
 	"metaData": {
-		"version": "3.17.0"
+		"version": "3.18.0"
 	},
 	"requests": [
 		{


### PR DESCRIPTION
Bump the meta model version to reflect the latest changes.