### PR TITLE
Add py-import-completer to the list of language servers

### DIFF
--- a/_implementors/servers.md
+++ b/_implementors/servers.md
@@ -217,6 +217,7 @@ index: 1
 | Python | [Samuel Roeca](https://github.com/pappasam) | [jedi-language-server](https://github.com/pappasam/jedi-language-server) | Python |
 | Python | [Shunsuke Shibayama](https://github.com/mtshiba) | [pylyzer](https://github.com/mtshiba/pylyzer) | Rust |
 | Python | [zubanls](https://zubanls.com/) | [zuban](https://github.com/zubanls/zuban) | Rust |
+| Python | [maniek2332](https://github.com/maniek2332) | [py-import-completer](https://github.com/maniek2332/py-import-completer) | Python |
 | Q# | [MS](https://github.com/microsoft/qsharp-compiler/graphs/contributors) | [Q# Language Server](https://github.com/microsoft/qsharp-compiler) | C# |
 | QML | [Qt](https://www.qt.io/) | [qmlls](https://github.com/qt/qtdeclarative/tree/dev/tools/qmlls) | C++ |
 | Query | [Riley Bruins](https://github.com/ribru17) | [ts_query_ls](https://github.com/ribru17/ts_query_ls) | Rust |


### PR DESCRIPTION
`py-import-completer` is a small language server, dedicated for performing import completions for Python. This PR adds a respective entry for it in `_implementors/servers.md`.