### PR TITLE
Add canipls language server to _implementors/servers.md

### DIFF
--- a/_implementors/servers.md
+++ b/_implementors/servers.md
@@ -122,6 +122,7 @@ index: 1
 | [Groovy](https://groovy-lang.org/) | [VsCode Groovy Lint](https://marketplace.visualstudio.com/items?itemName=NicolasVuillamy.vscode-groovy-lint) | [VsCode Groovy Lint Language Server](https://github.com/nvuillam/vscode-groovy-lint/tree/master/server) | TypeScript |
 | HTML | MS | [vscode-html-languageserver](https://github.com/Microsoft/vscode/tree/master/extensions/html-language-features/server) | TypeScript |
 | HTML | [Loris Cro](https://github.com/kristoff-it) | [SuperHTML](https://github.com/kristoff-it/superhtml) | Zig |
+| HTML/CSS/JavaScript | [Taylor Plewe](https://github.com/taylorplewe) | [canipls](https://github.com/taylorplewe/canipls) | Zig |
 | Haskell| [Alan Zimmerman](https://github.com/alanz) | [Haskell Language Server (HLS)](https://github.com/haskell/haskell-language-server) | Haskell |
 | [Haxe](https://haxe.org/) | [Haxe Foundation](https://github.com/HaxeFoundation/) | [Haxe Language Server](https://github.com/vshaxe/haxe-language-server) | Haxe |
 | [Helm (Kubernetes)](https://helm.sh/) | [qvalentin](https://github.com/qvalentin/) | [helm-ls](https://github.com/mrjosh/helm-ls) | Go |


### PR DESCRIPTION
[canipls](https://github.com/taylorplewe/canipls) is a linter which analyzes HTML, CSS and JavaScript code for web features which have low global browser support according to [caniuse.com](https://caniuse.com).

<img width="1422" height="153" alt="image" src="https://github.com/user-attachments/assets/35a656cc-b29c-4261-8b62-da9744518a5c" />

<img width="616" height="190" alt="image" src="https://github.com/user-attachments/assets/d3175378-3b94-4e64-8ec6-c387caa43dbd" />
