### PR TITLE
Add LSP Node protocol consistency skill

### DIFF
--- a/.github/skills/lsp-node-protocol-consistency/SKILL.md
+++ b/.github/skills/lsp-node-protocol-consistency/SKILL.md
@@ -1,0 +1,179 @@
+---
+name: lsp-node-protocol-consistency
+description: Keeps the Language Server Protocol specification and the vscode-languageserver-node TypeScript implementation aligned. Use when adding, changing, reviewing, or auditing LSP requests, notifications, capabilities, registration options, wire types, proposed or final status, since tags, meta-model data, or related documentation across microsoft/language-server-protocol and microsoft/vscode-languageserver-node.
+license: MIT
+compatibility: Requires local checkouts of microsoft/language-server-protocol and microsoft/vscode-languageserver-node, plus Node.js, npm, and git. Ruby and Bundler are optional for building the specification site.
+metadata:
+  author: microsoft
+  version: "1.0"
+---
+
+# LSP Node and specification consistency
+
+Maintain one coherent LSP wire contract across the normative specification and
+the Node implementation. Do not equate textual similarity with compatibility:
+TypeScript aliases, interfaces, intersections, helper namespaces, and factories
+can differ while describing the same wire shape.
+
+## Establish the scope
+
+1. Locate both repository roots instead of assuming fixed directory names:
+   - The specification root contains `_data/specifications.yml`.
+   - The Node root contains `protocol/package.json`, `types/src/main.ts`, and
+     `tools/src/metaModel.ts`.
+2. Read `git status --short --branch` in both repositories before editing.
+   Preserve unrelated changes. If task files already have conflicting edits,
+   ask how to proceed.
+3. Read `_data/specifications.yml` to identify the current LSP version unless
+   the user named a version. Do not update previous versions unless the task is
+   explicitly a historical correction.
+4. Determine whether the task is:
+   - an audit or review,
+   - a specification-first protocol change,
+   - an implementation correction, or
+   - synchronization of an already agreed contract.
+5. Identify the exact methods, capability paths, types, properties, enum
+   values, and documentation affected. Search both repositories for all of
+   them before changing files.
+
+If the intended wire behavior is ambiguous or the repositories disagree in a
+way the task does not resolve, stop and ask which behavior is intended.
+
+## Apply source-of-truth rules
+
+- The specification prose defines normative protocol behavior.
+- The Node TypeScript sources define the Node API and generate the meta model.
+- The specification's `metaModel.json`, `metaModel.ts`, and
+  `metaModel.schema.json` are mirrors of artifacts from the Node repository.
+- Never resolve a disagreement by blindly copying one side. Establish the
+  intended contract, update the authoritative source for each concern, and
+  then synchronize derived artifacts.
+
+Read [the consistency checklist](references/consistency-checklist.md) for the
+surface map and the invariants that must be checked.
+
+## Build a contract matrix
+
+For every affected request, notification, or type, record and compare:
+
+- method string and message direction;
+- parameter, result, error data, partial result, and registration types;
+- client and server capability paths;
+- static and dynamic registration behavior;
+- property names, optionality, nullability, arrays, maps, unions, and literals;
+- numeric or string enum values;
+- `@since`, deprecation, and proposed/final status;
+- behavioral requirements stated only in prose;
+- public exports and, where applicable, client/server feature wiring.
+
+Treat these distinctions as wire-significant:
+
+- omitted versus present with `null`;
+- optional versus required;
+- integer versus decimal;
+- an array versus a single value;
+- a literal value versus a general primitive;
+- client-to-server versus server-to-client versus both;
+- static capability advertisement versus dynamic registration.
+
+## Make coordinated changes
+
+When the task calls for edits, use an analogous completed feature as a pattern
+and update every applicable surface.
+
+### Specification repository
+
+Update the current version under `_specifications/lsp/<version>/`:
+
+- the feature or shared-type Markdown;
+- `specification.md` when a new topic must be included;
+- `_data/specification-<major>-<minor>-toc.yml` when navigation changes;
+- versioned message includes when the change affects shared messages;
+- the change log when the protocol version gains a user-visible feature.
+
+Keep prose examples and TypeScript snippets semantically aligned. Preserve
+anchors and links when moving or renaming content.
+
+### Node repository
+
+Update only the layers required by the change:
+
+- `types/src/main.ts` for serializable LSP data types and their public helpers;
+- `protocol/src/common/protocol.ts` for shared protocol types, capabilities,
+  imports, and exports;
+- `protocol/src/common/protocol.<feature>.ts` for feature-specific messages;
+- `protocol/src/common/api.ts` for public API exposure when needed;
+- `client/src/common/` for client capability, registration, conversion, and
+  middleware support;
+- `server/src/common/` for typed server handlers and feature exposure;
+- focused unit or integration tests for changed runtime behavior.
+
+Not every wire change requires client or server feature code. Explain why a
+layer is not applicable rather than adding empty plumbing.
+
+## Regenerate and synchronize the meta model
+
+After changing Node protocol or type sources:
+
+1. Compile the affected Node workspaces.
+2. From the Node `protocol` workspace, run `npm run compile:metaModelTool`.
+3. From the Node repository root, run:
+   - `npm run generate:metaModel`
+   - `npm run generate:metaModelSchema`
+4. Inspect the generated diff. Unexpected additions, omissions, reordered
+   declarations, or lost documentation usually indicate an implementation or
+   generator-modeling error; fix the source instead of hand-editing generated
+   JSON.
+5. Copy the intended generated artifacts to the current specification:
+   - `protocol/metaModel.json` to
+     `_specifications/lsp/<version>/metaModel/metaModel.json`;
+   - `tools/src/metaModel.ts` to
+     `_specifications/lsp/<version>/metaModel/metaModel.ts`;
+   - `protocol/metaModel.schema.json` to
+     `_specifications/lsp/<version>/metaModel/metaModel.schema.json`.
+6. Run the bundled comparison from the specification root:
+
+   `node .github/skills/lsp-node-protocol-consistency/scripts/compare-meta-model.mjs --node-repo <node-repository-root>`
+
+The comparison is read-only. It compares JSON semantically so irrelevant
+object-key ordering does not create false failures, while array ordering and
+all values remain significant.
+
+Meta-model equality is necessary but not sufficient. It does not prove that
+normative prose, examples, client/server behavior, or runtime helpers agree.
+
+## Validate
+
+Use the smallest existing commands that cover the changed layers, escalating
+only when needed:
+
+- Node type changes: `npm run compile:types`, then the `types` lint and tests.
+- Protocol changes: `npm run compile:protocol`, then the `protocol` lint and
+  Node tests.
+- Server changes: compile, lint, and test the `server` workspace.
+- Client changes: compile and lint `client`; run the focused
+  `client-node-tests` integration tests that exercise the feature.
+- Specification Markdown, includes, or navigation: run
+  `bundle exec jekyll build` when the repository's Ruby dependencies are
+  available.
+- Both repositories: run `git diff --check`.
+- Always rerun the bundled meta-model comparison after synchronization.
+
+Do not install or upgrade dependencies merely to complete an audit. If a
+required existing tool is unavailable, report the exact validation that could
+not run.
+
+## Report the result
+
+State:
+
+- the two repository roots, branches, and target LSP version;
+- the contract surfaces checked;
+- files changed in each repository;
+- generated artifacts synchronized;
+- validation commands and outcomes;
+- any unresolved divergence or validation gap.
+
+For audits, report each mismatch with the specification evidence, Node
+evidence, wire or API impact, and the recommended authoritative fix. Do not
+claim consistency when only the meta-model files were compared.

--- a/.github/skills/lsp-node-protocol-consistency/references/consistency-checklist.md
+++ b/.github/skills/lsp-node-protocol-consistency/references/consistency-checklist.md
@@ -1,0 +1,109 @@
+# Consistency checklist
+
+Use this reference after identifying the feature or types in scope.
+
+## Surface map
+
+| Concern | Specification repository | Node repository |
+| --- | --- | --- |
+| Current version | `_data/specifications.yml` | `protocol/package.json` and meta-model metadata |
+| Feature prose and snippets | `_specifications/lsp/<version>/<area>/<feature>.md` | Relevant files below |
+| Shared wire data | Feature or `types/*.md` pages | `types/src/main.ts` |
+| Request or notification | Feature page | `protocol/src/common/protocol.<feature>.ts` or `protocol.ts` |
+| Capabilities | Feature page and `general/initialize.md` | `ClientCapabilities` and `ServerCapabilities` in protocol sources |
+| Public protocol exports | TypeScript snippets imply public names | `protocol/src/common/protocol.ts` and `api.ts` |
+| Client integration | Normative client behavior | `client/src/common/`, converters, middleware, and tests |
+| Server integration | Normative server behavior | `server/src/common/` and tests |
+| Machine-readable contract | `metaModel/metaModel.json` | Generated `protocol/metaModel.json` |
+| Meta-model types | `metaModel/metaModel.ts` | `tools/src/metaModel.ts` |
+| Meta-model schema | `metaModel/metaModel.schema.json` | Generated `protocol/metaModel.schema.json` |
+| Navigation and release notes | Version TOC and change log | Usually not applicable |
+
+The Node meta-model generator reads the protocol TypeScript program, including
+types imported from `@vscode/languageserver-types`. A missing generated entry
+can therefore originate in either `types/src/main.ts`, protocol declarations,
+exports, or generator-recognition conventions.
+
+## Request and notification checks
+
+- Exact method string, including `$`, slashes, and casing.
+- Correct direction.
+- Request versus notification.
+- Parameter type and whether parameters may be omitted.
+- Result type, including `null`, arrays, and unions.
+- Partial-result and work-done-progress types.
+- Error-data type when protocol-specific.
+- Registration-options type.
+- Client capability path.
+- Server capability path.
+- Static registration identifier support.
+- Dynamic registration support.
+- Cancellation and retrigger behavior stated in prose.
+
+## Type checks
+
+- Public type name and link target.
+- Structure inheritance or intersection members.
+- Every property name and documentation.
+- Required versus optional.
+- Nullable versus non-nullable.
+- Primitive kind, especially `integer`, `uinteger`, and `decimal`.
+- Array element type and map key/value types.
+- Union alternatives and literal values.
+- Enum representation and exact numeric or string values.
+- Recursive references and aliases.
+- Serialization shape; helper factories and guards must not change it.
+- `@since`, `@deprecated`, and `@proposed` metadata.
+
+Type aliases and interfaces can be equivalent. Compare their resulting wire
+shapes rather than requiring the same TypeScript syntax. Conversely, do not
+treat `property?: T` as equivalent to `property: T | null`.
+
+## Capability and registration checks
+
+- Client capability is nested under the documented path.
+- Server capability uses the documented property and value type.
+- Boolean shorthand is supported only when the specification permits it.
+- Registration options include the documented selector and static ID mixins.
+- The message descriptor uses the same registration-options type.
+- Client code advertises and consumes the capability consistently.
+- Server APIs expose handlers only for valid directions.
+
+## Stability and version checks
+
+- New stable additions carry the intended `@since <major>.<minor>.<patch>`.
+- Proposed declarations remain marked proposed on both sides.
+- Finalizing a proposal removes proposal markers and moves/exports declarations
+  according to established Node conventions.
+- Deprecation text names the replacement when one exists.
+- Patch-level corrections do not accidentally claim a new minor version.
+- Previous specification versions stay unchanged unless the task explicitly
+  corrects historical documentation.
+- Package version bumps are release work and are not implied by a contract
+  consistency fix.
+
+## Runtime integration checks
+
+Apply these only when the Node client or server implements the feature:
+
+- Public feature registration and initialization.
+- Protocol-to-editor and editor-to-protocol conversion.
+- Middleware or handler signatures.
+- Cancellation-token propagation.
+- Partial-result and progress handling.
+- Dynamic registration and unregistration.
+- Capability negotiation and fallback behavior.
+- Node and browser entry-point exposure where applicable.
+- Focused tests for serialization, conversion, registration, and handlers.
+
+## Completion gate
+
+Consistency is established only when:
+
+1. the normative prose and snippets describe the intended behavior;
+2. Node wire declarations encode the same contract;
+3. applicable client/server behavior honors it;
+4. generated Node meta-model artifacts are current;
+5. specification meta-model mirrors match semantically;
+6. affected builds, lints, and tests pass;
+7. no unexplained divergence remains in either repository.

--- a/.github/skills/lsp-node-protocol-consistency/scripts/compare-meta-model.mjs
+++ b/.github/skills/lsp-node-protocol-consistency/scripts/compare-meta-model.mjs
@@ -1,0 +1,317 @@
+#!/usr/bin/env node
+
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url));
+const defaultSpecRepository = resolve(scriptDirectory, '..', '..', '..', '..');
+
+function printUsage() {
+	console.log(`Usage:
+  node compare-meta-model.mjs --node-repo <path> [--spec-repo <path>] [--spec-version <major.minor>]
+
+Options:
+  --node-repo     Root of microsoft/vscode-languageserver-node.
+  --spec-repo     Root of microsoft/language-server-protocol.
+                  Defaults to the repository containing this skill.
+  --spec-version  LSP specification series, for example 3.18.
+                  Defaults to the entry marked Current in specifications.yml.
+  --help          Show this help.
+
+The VSCODE_LANGUAGESERVER_NODE_REPO environment variable can be used instead
+of --node-repo.`);
+}
+
+function fail(message) {
+	console.error(`Error: ${message}`);
+	process.exitCode = 2;
+}
+
+function parseArguments(argumentsToParse) {
+	const options = {};
+
+	for (let index = 0; index < argumentsToParse.length; index++) {
+		const argument = argumentsToParse[index];
+		if (argument === '--help') {
+			options.help = true;
+			continue;
+		}
+
+		if (argument !== '--node-repo' && argument !== '--spec-repo' && argument !== '--spec-version') {
+			throw new Error(`Unknown argument: ${argument}`);
+		}
+
+		const value = argumentsToParse[++index];
+		if (value === undefined || value.startsWith('--')) {
+			throw new Error(`Missing value for ${argument}`);
+		}
+
+		if (argument === '--node-repo') {
+			options.nodeRepository = value;
+		} else if (argument === '--spec-repo') {
+			options.specRepository = value;
+		} else {
+			options.specVersion = value;
+		}
+	}
+
+	return options;
+}
+
+function hasMarkers(repository, markers) {
+	return markers.every((marker) => existsSync(join(repository, marker)));
+}
+
+function validateSpecRepository(repository) {
+	const markers = [
+		'_data/specifications.yml',
+		'_specifications/lsp'
+	];
+
+	if (!hasMarkers(repository, markers)) {
+		throw new Error(
+			`Specification repository not found at "${repository}". ` +
+			`Expected ${markers.join(' and ')}.`
+		);
+	}
+}
+
+function validateNodeRepository(repository) {
+	const markers = [
+		'protocol/package.json',
+		'tools/src/metaModel.ts',
+		'types/src/main.ts'
+	];
+
+	if (!hasMarkers(repository, markers)) {
+		throw new Error(
+			`Node repository not found at "${repository}". ` +
+			`Expected ${markers.join(', ')}.`
+		);
+	}
+}
+
+function findNodeRepository(specRepository, requestedRepository) {
+	if (requestedRepository !== undefined) {
+		const repository = resolve(requestedRepository);
+		validateNodeRepository(repository);
+		return repository;
+	}
+
+	const environmentRepository = process.env.VSCODE_LANGUAGESERVER_NODE_REPO;
+	if (environmentRepository !== undefined && environmentRepository.length > 0) {
+		const repository = resolve(environmentRepository);
+		validateNodeRepository(repository);
+		return repository;
+	}
+
+	const parent = dirname(specRepository);
+	const candidates = [
+		join(parent, 'vscode-languageserver-node'),
+		join(parent, 'Node')
+	];
+
+	for (const candidate of candidates) {
+		if (hasMarkers(candidate, [
+			'protocol/package.json',
+			'tools/src/metaModel.ts',
+			'types/src/main.ts'
+		])) {
+			return candidate;
+		}
+	}
+
+	throw new Error(
+		'Unable to locate microsoft/vscode-languageserver-node. ' +
+		'Pass --node-repo or set VSCODE_LANGUAGESERVER_NODE_REPO.'
+	);
+}
+
+function readCurrentSpecVersion(specRepository) {
+	const configurationPath = join(specRepository, '_data', 'specifications.yml');
+	const configuration = readFileSync(configurationPath, 'utf8');
+	const lspSection = configuration.split(/\r?\n- title:\s+LSIF(?:\r?\n|$)/u)[0];
+	const currentMatch = lspSection.match(
+		/^\s*-\s+title:\s+(\d+\.\d+)\s+\(Current\)\s*$[\s\S]*?^\s+version:\s+(\d+\.\d+)\s*$/mu
+	);
+
+	if (currentMatch === null) {
+		throw new Error(`No current LSP version found in "${configurationPath}".`);
+	}
+
+	if (currentMatch[1] !== currentMatch[2]) {
+		throw new Error(
+			`Current LSP title ${currentMatch[1]} does not match version ${currentMatch[2]} ` +
+			`in "${configurationPath}".`
+		);
+	}
+
+	return currentMatch[1];
+}
+
+function validateSpecVersion(version) {
+	if (!/^\d+\.\d+$/u.test(version)) {
+		throw new Error(`Invalid specification version "${version}". Expected <major>.<minor>.`);
+	}
+}
+
+function canonicalize(value) {
+	if (Array.isArray(value)) {
+		return value.map(canonicalize);
+	}
+
+	if (value !== null && typeof value === 'object') {
+		return Object.fromEntries(
+			Object.keys(value)
+				.sort()
+				.map((key) => [key, canonicalize(value[key])])
+		);
+	}
+
+	return value;
+}
+
+function readJson(filePath) {
+	return JSON.parse(readFileSync(filePath, 'utf8'));
+}
+
+function jsonFilesEqual(leftPath, rightPath) {
+	const left = JSON.stringify(canonicalize(readJson(leftPath)));
+	const right = JSON.stringify(canonicalize(readJson(rightPath)));
+	return left === right;
+}
+
+function textFilesEqual(leftPath, rightPath) {
+	const normalize = (value) => value.replace(/\r\n?/gu, '\n');
+	return normalize(readFileSync(leftPath, 'utf8')) === normalize(readFileSync(rightPath, 'utf8'));
+}
+
+function relativeArtifactPaths(specVersion) {
+	return [
+		{
+			label: 'Protocol meta model',
+			nodePath: join('protocol', 'metaModel.json'),
+			specPath: join('_specifications', 'lsp', specVersion, 'metaModel', 'metaModel.json'),
+			compare: jsonFilesEqual,
+			mode: 'semantic JSON'
+		},
+		{
+			label: 'Meta-model TypeScript definitions',
+			nodePath: join('tools', 'src', 'metaModel.ts'),
+			specPath: join('_specifications', 'lsp', specVersion, 'metaModel', 'metaModel.ts'),
+			compare: textFilesEqual,
+			mode: 'text with normalized line endings'
+		},
+		{
+			label: 'Meta-model JSON schema',
+			nodePath: join('protocol', 'metaModel.schema.json'),
+			specPath: join('_specifications', 'lsp', specVersion, 'metaModel', 'metaModel.schema.json'),
+			compare: jsonFilesEqual,
+			mode: 'semantic JSON'
+		}
+	];
+}
+
+function compareArtifacts(nodeRepository, specRepository, specVersion) {
+	const failures = [];
+
+	for (const artifact of relativeArtifactPaths(specVersion)) {
+		const nodePath = join(nodeRepository, artifact.nodePath);
+		const specPath = join(specRepository, artifact.specPath);
+
+		if (!existsSync(nodePath)) {
+			console.error(`FAIL ${artifact.label}: missing Node artifact "${nodePath}"`);
+			failures.push(artifact.label);
+			continue;
+		}
+
+		if (!existsSync(specPath)) {
+			console.error(`FAIL ${artifact.label}: missing specification artifact "${specPath}"`);
+			failures.push(artifact.label);
+			continue;
+		}
+
+		if (!artifact.compare(nodePath, specPath)) {
+			console.error(`FAIL ${artifact.label} (${artifact.mode})`);
+			console.error(`     Node: ${nodePath}`);
+			console.error(`     Spec: ${specPath}`);
+			failures.push(artifact.label);
+			continue;
+		}
+
+		console.log(`PASS ${artifact.label} (${artifact.mode})`);
+	}
+
+	return failures;
+}
+
+function validateMetaModelVersion(nodeRepository, specVersion) {
+	const metaModelPath = join(nodeRepository, 'protocol', 'metaModel.json');
+	const metaModel = readJson(metaModelPath);
+	const modelVersion = metaModel?.metaData?.version;
+
+	if (typeof modelVersion !== 'string') {
+		console.error(`FAIL Meta-model version: missing metaData.version in "${metaModelPath}"`);
+		return false;
+	}
+
+	const modelSeries = modelVersion.split('.').slice(0, 2).join('.');
+	if (modelSeries !== specVersion) {
+		console.error(
+			`FAIL Meta-model version: Node model ${modelVersion} targets ${modelSeries}, ` +
+			`not specification ${specVersion}`
+		);
+		return false;
+	}
+
+	console.log(`PASS Meta-model version ${modelVersion} targets specification ${specVersion}`);
+	return true;
+}
+
+let options;
+try {
+	options = parseArguments(process.argv.slice(2));
+} catch (error) {
+	fail(error instanceof Error ? error.message : String(error));
+	printUsage();
+}
+
+if (options !== undefined && options.help === true) {
+	printUsage();
+} else if (options !== undefined) {
+	try {
+		const specRepository = resolve(options.specRepository ?? defaultSpecRepository);
+		validateSpecRepository(specRepository);
+
+		const specVersion = options.specVersion ?? readCurrentSpecVersion(specRepository);
+		validateSpecVersion(specVersion);
+
+		const nodeRepository = findNodeRepository(specRepository, options.nodeRepository);
+
+		console.log(`Specification repository: ${specRepository}`);
+		console.log(`Node repository:          ${nodeRepository}`);
+		console.log(`LSP version:              ${specVersion}`);
+		console.log('');
+
+		const failures = compareArtifacts(nodeRepository, specRepository, specVersion);
+		if (!validateMetaModelVersion(nodeRepository, specVersion)) {
+			failures.push('Meta-model version');
+		}
+
+		if (failures.length > 0) {
+			console.error('');
+			console.error(`Meta-model consistency failed (${failures.length} check(s)).`);
+			console.error(
+				'Regenerate the Node artifacts, inspect the generated diff, synchronize the ' +
+				'intended files into the specification, and rerun this command.'
+			);
+			process.exitCode = 1;
+		} else {
+			console.log('');
+			console.log('All mirrored meta-model artifacts are consistent.');
+		}
+	} catch (error) {
+		fail(error instanceof Error ? error.message : String(error));
+	}
+}


### PR DESCRIPTION
## Summary

- add a reusable skill for coordinated LSP specification and vscode-languageserver-node changes
- document the contract surfaces and invariants required for consistency audits and protocol updates
- add a read-only comparison script for the generated meta-model JSON, TypeScript definitions, and JSON schema

## Validation

- `node --check .github/skills/lsp-node-protocol-consistency/scripts/compare-meta-model.mjs`
- `node .github/skills/lsp-node-protocol-consistency/scripts/compare-meta-model.mjs --help`
- `node .github/skills/lsp-node-protocol-consistency/scripts/compare-meta-model.mjs --node-repo C:\Users\dirkb\Projects\mseng\LanguageServer\Node`
- `git diff --cached --check`

The comparison reports all mirrored LSP 3.18 meta-model artifacts as consistent.