### PR TITLE
Add Eastwood (Clean Language Server) to implementors

### DIFF
--- a/_implementors/servers.md
+++ b/_implementors/servers.md
@@ -56,6 +56,7 @@ index: 1
 | CSS/LESS/SASS | MS | [vscode-css-languageserver](https://github.com/Microsoft/vscode/tree/master/extensions/css-language-features/server) | TypeScript |
 | [Ceylon](https://ceylon-lang.org/) | [John Vasileff](https://github.com/jvasileff) | [vscode-ceylon](https://github.com/jvasileff/vscode-ceylon) | Ceylon |
 | [Clarity](https://docs.stacks.co/docs/write-smart-contracts/) | [Hiro](https://hiro.so) | [clarity-lsp](https://github.com/hirosystems/clarity-lsp) | TypeScript |
+| [Clean](https://clean-lang.org/) | [TOP Software Technology](https://www.top-software.nl) | [Eastwood](https://gitlab.com/top-software/eastwood) | Clean |
 | [Clojure](https://clojure.org/) | [Eric Dallo](https://github.com/ericdallo) | [clojure-lsp](https://github.com/clojure-lsp/clojure-lsp) | Clojure |
 | [CMake](https://cmake.org/) | [regen100](https://github.com/regen100) | [cmake-language-server](https://github.com/regen100/cmake-language-server) | Python |
 | [CMake](https://cmake.org/) | [Decodetalkers](https://github.com/Decodetalkers) | [neocmakelsp](https://github.com/Decodetalkers/neocmakelsp) | Rust |


### PR DESCRIPTION
This merge request adds an entry for Eastwood, the language server for the functional programming language [Clean](https://clean-lang.org/).